### PR TITLE
Added support for text labels in to_tensorflow, to_pytorch

### DIFF
--- a/examples/fashion-mnist/train_pytorch.py
+++ b/examples/fashion-mnist/train_pytorch.py
@@ -68,7 +68,7 @@ def main():
     torch.manual_seed(random_seed)
 
     # Load data
-    ds = dataset.load("abhinavtuli/fashion-mnist")
+    ds = dataset.load("mnist/fashion-mnist")
 
     # Transform into pytorch
     ds = ds.to_pytorch()
@@ -88,6 +88,19 @@ def main():
         train(model, train_loader, optimizer)
         print("Training Epoch {} finished\n".format(epoch))
         test(model, test_loader)
+
+    # sanity check to see outputs of model
+    for batch in test_loader:
+        print("\nNamed Labels:",dataset.get_text(batch["named_labels"]))
+        print("\nLabels:",batch["labels"])
+
+        data = batch["data"]
+        data = torch.unsqueeze(data, 1)
+
+        output = model(data)
+        pred = output.data.max(1)[1]
+        print("\nPredictions:",pred)
+        break
 
 
 if __name__ == "__main__":

--- a/examples/fashion-mnist/train_pytorch.py
+++ b/examples/fashion-mnist/train_pytorch.py
@@ -71,7 +71,8 @@ def main():
     ds = dataset.load("mnist/fashion-mnist")
 
     # Transform into pytorch
-    ds = ds.to_pytorch()
+    # max_text_len is an optional argument that sets the maximum length of text labels, default is 30
+    ds = ds.to_pytorch(max_text_len=15)
 
     # Splitting back into the original train and test sets, instead of random split
     train_dataset = torch.utils.data.Subset(ds, range(60000))

--- a/examples/fashion-mnist/train_tf_fit.py
+++ b/examples/fashion-mnist/train_tf_fit.py
@@ -29,7 +29,7 @@ def main():
     EPOCHS = 3
 
     # Load data
-    ds = dataset.load("abhinavtuli/fashion-mnist")
+    ds = dataset.load("mnist/fashion-mnist")
 
     # transform into Tensorflow dataset
     ds = ds.to_tensorflow()

--- a/examples/fashion-mnist/train_tf_fit.py
+++ b/examples/fashion-mnist/train_tf_fit.py
@@ -32,7 +32,8 @@ def main():
     ds = dataset.load("mnist/fashion-mnist")
 
     # transform into Tensorflow dataset
-    ds = ds.to_tensorflow()
+    # max_text_len is an optional argument that fixes the maximum length of text labels
+    ds = ds.to_tensorflow(max_text_len = 15)
 
     # converting ds so that it can be directly used in model.fit
     ds = ds.map(lambda x: to_model_fit(x))

--- a/examples/fashion-mnist/train_tf_gradient_tape.py
+++ b/examples/fashion-mnist/train_tf_gradient_tape.py
@@ -60,7 +60,8 @@ def main():
     ds = dataset.load("mnist/fashion-mnist")
 
     # transform into Tensorflow dataset
-    ds = ds.to_tensorflow()
+    # max_text_len is an optional argument that sets the maximum length of text labels, default is 30
+    ds = ds.to_tensorflow(max_text_len = 15)
 
     # Splitting back into the original train and test sets
     train_dataset = ds.take(60000)

--- a/examples/fashion-mnist/train_tf_gradient_tape.py
+++ b/examples/fashion-mnist/train_tf_gradient_tape.py
@@ -2,6 +2,7 @@ from hub import dataset
 import tensorflow as tf
 from tensorflow.keras.losses import SparseCategoricalCrossentropy
 from tensorflow.keras.optimizers import Adam
+import numpy as np
 
 
 def create_CNN():
@@ -56,7 +57,7 @@ def main():
     loss_fn = SparseCategoricalCrossentropy()
 
     # Load data
-    ds = dataset.load("abhinavtuli/fashion-mnist")
+    ds = dataset.load("mnist/fashion-mnist")
 
     # transform into Tensorflow dataset
     ds = ds.to_tensorflow()
@@ -77,6 +78,16 @@ def main():
         print("Training Epoch {} finished\n".format(epoch))
         test(model, test_dataset, test_acc_metric)
 
+    # sanity check to see outputs of model
+    for batch in test_dataset:
+        print("\nNamed Labels:",dataset.get_text(batch["named_labels"]))
+        print("\nLabels:",batch["labels"])
+
+        output = model(tf.expand_dims(batch["data"], axis=3), training=False)
+        print(type(output))
+        pred = np.argmax(output, axis=-1)
+        print("\nPredictions:",pred)
+        break
 
 if __name__ == "__main__":
     main()

--- a/examples/fashion-mnist/upload.py
+++ b/examples/fashion-mnist/upload.py
@@ -15,7 +15,6 @@ def load_fashion_mnist(dataset="training", digits=np.arange(10), path=".", size=
     elif dataset == "testing":
         fname_img = os.path.join(path, "t10k-images-idx3-ubyte")
         fname_lbl = os.path.join(path, "t10k-labels-idx1-ubyte")
-
     else:
         raise ValueError("dataset must be 'testing' or 'training'")
 
@@ -43,32 +42,37 @@ def load_fashion_mnist(dataset="training", digits=np.arange(10), path=".", size=
 
 
 def main():
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "-d",
-        "--dataset_path",
-        type=str,
-        help="Path to fashion-mnist dataset",
-        default="./data/fashion-mnist",
-    )
-    parser.add_argument(
-        "-o", "--output_name", type=str, help="Dataset output name", default="fashion-mnist",
-    )
-    args = parser.parse_args()
     files = ["training", "testing"]
     dicts = []
+
+    # required to generate named labels
+    mapping = {0: "T-shirt/top",
+               1: "Trouser",
+               2: "Pullover",
+               3: "Dress",
+               4: "Coat",
+               5: "Sandal",
+               6: "Shirt",
+               7: "Sneaker",
+               8: "Bag",
+               9: "Ankle boot"
+               }
+
     for f in files:
-        images, labels = load_fashion_mnist(f, path=args.dataset_path)
+        images, labels = load_fashion_mnist(f, path="./data/fashion-mnist")
         dicts += [{"images": images, "labels": labels}]
+
     images = np.concatenate([d["images"] for d in dicts])
     labels = np.concatenate([np.array(d["labels"], dtype="int8") for d in dicts])
+    named_labels = np.array([mapping[label] for label in labels])
     print(images.shape, labels.shape)
 
     images_t = tensor.from_array(images, dtag="mask")
-    labels_t = tensor.from_array(labels)
+    labels_t = tensor.from_array(labels, dtag="text")
+    named_labels_t = tensor.from_array(named_labels, dtag="text")
 
-    ds = dataset.from_tensors({"data": images_t, "labels": labels_t})
-    ds.store(f"{args.output_name}")
+    ds = dataset.from_tensors({"data": images_t, "labels": labels_t, "named_labels": named_labels_t})
+    ds.store("mnist/fashion-mnist")
 
 
 if __name__ == "__main__":

--- a/hub/collections/dataset/__init__.py
+++ b/hub/collections/dataset/__init__.py
@@ -5,7 +5,7 @@ import dask
 import dask.array
 import numpy as np
 
-from .core import Dataset, DatasetGenerator, load, _dask_shape
+from .core import Dataset, DatasetGenerator, load, _dask_shape, get_text
 from hub.collections.tensor import Tensor
 
 

--- a/hub/collections/dataset/core.py
+++ b/hub/collections/dataset/core.py
@@ -567,12 +567,20 @@ class Dataset:
             ----------
             transform: func
                 any transform that takes input a dictionary of a sample and returns transformed dictionary 
+            max_text_len: integer
+                the maximum length of text strings that would be stored. Strings longer than this would be snipped
         """
         return TorchDataset(self, transform, max_text_len)
 
     def to_tensorflow(self, max_text_len = 30):
         """
             Transforms into tensorflow dataset
+            
+            Parameters
+            ----------
+            max_text_len: integer
+                the maximum length of text strings that would be stored. Strings longer than this would be snipped
+
         """
         try:
             import tensorflow as tf

--- a/hub/collections/dataset/core.py
+++ b/hub/collections/dataset/core.py
@@ -588,24 +588,41 @@ class Dataset:
                         arrs
                     )
                     arrs = arrs.compute()
+                    for ind,arr in enumerate(arrs):
+                        if arr.dtype.type is np.str_:
+                            arr = [([ord(x) for x in sample.tolist()]) for sample in arr]
+                            arr = np.array([np.pad(sample, (0, 20-len(sample)), 'constant', constant_values=(32)) for sample in arr])
+                            arrs[ind]=arr
+                            
                     for i in range(step):
                         sample = {key: r[i] for key, r in zip(self[index].keys(), arrs)}
                         yield sample
 
         def tf_dtype(np_dtype):
             try:
+                if "U" in np_dtype:
+                    return tf.dtypes.as_dtype("string")
                 return tf.dtypes.as_dtype(np_dtype)
             except Exception as e:
                 return tf.variant
+
+        output_shapes={}
+        output_types={}
+        for key in self.keys():
+            output_types[key]=tf_dtype(self._tensors[key].dtype)
+            output_shapes[key]= self._tensors[key].shape[1:]
+
+            # if this is a string, we change the type to int, as it's going to become ascii. shape is also set to None
+            if output_types[key]==tf.dtypes.as_dtype("string"):
+                output_types[key]=tf.dtypes.as_dtype("int8")
+                output_shapes[key]=None
 
         # TODO use None for dimensions you don't know the length tf.TensorShape([None])
         # FIXME Dataset Generator is not very good with multiprocessing but its good for fast tensorflow support
         return tf.data.Dataset.from_generator(
             tf_gen,
-            output_types={
-                key: tf_dtype(self._tensors[key].dtype) for key in self.keys()
-            },
-            output_shapes={key: self._tensors[key].shape[1:] for key in self.keys()},
+            output_types=output_types,
+            output_shapes=output_shapes,
         )
 
 
@@ -626,6 +643,26 @@ def _numpy_load(
         raise Exception(
             f"Dataset file {filepath} does not exists. Your dataset data is likely to be corrupted"
         )
+
+def get_text(input):
+    """ Converts strings stored as ascii value tensors back into strings
+    """
+    if input.ndim==1:
+        try: 
+            text = "".join([chr(x) for x in input]).rstrip()
+            return text
+        except Exception as e:
+            logger.error(traceback.format_exc() + str(e))
+            raise Exception("get_text can only be called on a tensor of text or a batch of tensors of text")
+    elif input.ndim==2:
+        try:
+            text= ["".join([chr(x) for x in sample]).rstrip() for sample in input]
+            return text
+        except Exception as e:
+            logger.error(traceback.format_exc() + str(e))
+            raise Exception("get_text can only be called on a tensor of text or a batch of tensors of text")
+    else:
+        raise Exception(f"Got input of dimension {input.ndim} for get_text. Expected dimension of 1 or 2")
 
 
 def load(tag, creds=None, session_creds=True) -> Dataset:
@@ -746,6 +783,9 @@ class TorchDataset:
 
     def _to_tensor(self, key, sample):
         if key not in self._dynkeys:
+            if isinstance(sample, np.str_):
+                sample = np.array([ord(x) for x in sample.tolist()])
+                sample=np.pad(sample, (0, 20-len(sample)), 'constant',constant_values=(32))
             return torch.tensor(sample)
         else:
             return [torch.tensor(item) for item in sample]


### PR DESCRIPTION
to_tensorflow and to_pytorch now work properly even when text labels present by converting such labels to ascii. 
Also, updated fashion-mnist code, which had stopped working after named_labels were added. Examples of conversion back from ascii to text are present in train_tf_gradient_tape.py and train_pytorch.py in fashion-mnist. 