### PR TITLE
Locust now only pushes a summary when PR is opened

### DIFF
--- a/.github/workflows/locust.yaml
+++ b/.github/workflows/locust.yaml
@@ -1,6 +1,8 @@
 name: Locust summary
 
-on: [ pull_request_target ]
+on:
+  pull_request_target:
+    types: [opened, reopened]
 
 jobs:
   build:


### PR DESCRIPTION
This should reduce any noise Locust may be creating on PRs that get
synchronized often while providing the same value for larger changes.