### PR TITLE
 Enhancements to converters

### DIFF
--- a/examples/eurosat.py
+++ b/examples/eurosat.py
@@ -1,0 +1,41 @@
+import hub
+import torch
+
+if __name__ == "__main__":
+    ds = hub.Dataset("eurosat/eurosat-rgb")
+
+    # 26000 samples in dataset, accessing values
+    print(ds["image"][10].numpy())
+    print(ds["label", 15].numpy())  # alternate way to access, by specifying both key and sample number at once
+    print(ds["filename", 20:22].numpy())  # accessing multiple elements at once
+
+    # Splitting into train and test sets
+    train_ds = ds[:13000]
+    test_ds = ds[13000:]
+
+    # Using hub with tensorflow
+    train_tf_ds = train_ds.to_tensorflow().batch(2)
+
+    for batch in train_tf_ds:
+        print(batch["label"], batch["filename"], batch["image"])
+        break
+
+    test_tf_ds = test_ds.to_tensorflow().batch(2)
+
+    for batch in test_tf_ds:
+        print(batch["label"], batch["filename"], batch["image"])
+        break
+
+    # Using hub with pytorch
+    train_pt_ds = train_ds.to_pytorch()
+    train_loader = torch.utils.data.DataLoader(train_pt_ds, batch_size=2)
+
+    for batch in train_loader:
+        print(batch["label"], batch["image"])  # pytorch tensors don't support text labels such as filename
+        break
+
+    test_pt_ds = test_ds.to_pytorch()
+    test_loader = torch.utils.data.DataLoader(test_pt_ds, batch_size=2)
+    for batch in test_loader:
+        print(batch["label"], batch["image"])  # pytorch tensors don't support text labels such as filename
+        break

--- a/hub/api/datasetview.py
+++ b/hub/api/datasetview.py
@@ -124,3 +124,9 @@ class DatasetView:
         if len(tensor_dict) == 0:
             raise KeyError(f"Key {subpath} was not found in dataset")
         return tensor_dict
+
+    def to_tensorflow(self):
+        return self.dataset.to_tensorflow(num=self.num_samples, ofs=self.offset)
+
+    def to_pytorch(self, Transform=None):
+        return self.dataset.to_pytorch(Transform=Transform, num=self.num_samples, ofs=self.offset)

--- a/hub/api/datasetview.py
+++ b/hub/api/datasetview.py
@@ -126,7 +126,9 @@ class DatasetView:
         return tensor_dict
 
     def to_tensorflow(self):
-        return self.dataset.to_tensorflow(num=self.num_samples, ofs=self.offset)
+        """Converts the dataset into a tensorflow compatible format"""
+        return self.dataset.to_tensorflow(num_samples=self.num_samples, offset=self.offset)
 
     def to_pytorch(self, Transform=None):
-        return self.dataset.to_pytorch(Transform=Transform, num=self.num_samples, ofs=self.offset)
+        """Converts the dataset into a pytorch compatible format"""
+        return self.dataset.to_pytorch(Transform=Transform, num_samples=self.num_samples, offset=self.offset)

--- a/hub/api/tests/test_converters.py
+++ b/hub/api/tests/test_converters.py
@@ -56,6 +56,7 @@ def test_to_from_tensorflow():
         ).all()
         assert (
             res_ds["named_label", i].numpy().decode('utf-8') == 'try' + str(i)
+        )
 
 
 @pytest.mark.skipif(not pytorch_loaded(), reason="requires pytorch to be loaded")

--- a/hub/api/tests/test_converters.py
+++ b/hub/api/tests/test_converters.py
@@ -40,11 +40,13 @@ def test_to_from_tensorflow():
             "d": {"e": Tensor((5, 3), "uint8")},
             "f": "float"
         },
+        "named_label": "object"
     }
 
     ds = hub.Dataset(schema=my_schema, shape=(10,), url="./data/test_from_tf/ds3", mode="w")
     for i in range(10):
         ds["label", "d", "e", i] = i * np.ones((5, 3))
+        ds["named_label", i] = 'try' + str(i)
     ds = ds.to_tensorflow()
     out_ds = hub.Dataset.from_tensorflow(ds)
     res_ds = out_ds.store("./data/test_from_tf/ds4", length=10)  # generator has no length, argument needed
@@ -52,6 +54,8 @@ def test_to_from_tensorflow():
         assert (
             res_ds["label", "d", "e", i].numpy() == i * np.ones((5, 3))
         ).all()
+        assert (
+            res_ds["named_label", i].numpy().decode('utf-8') == 'try' + str(i)
 
 
 @pytest.mark.skipif(not pytorch_loaded(), reason="requires pytorch to be loaded")


### PR DESCRIPTION
to_tensorflow now supports text labels, added tests as well. to_pytorch doesn't, as pytorch tensors can't hold strings/bytes
Also added both to converters to datasetview view.
Added Eurosat example that includes both of these things and would also be useful to Omdena users.