### PR TITLE
Fix inclusion of non python files in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt


### PR DESCRIPTION
fixes #142 

This patch adds a manifest file which can be used to add non-python files to the sdist tarball 

Local installation tested in a new environment 

Signed-off-by: Aditya Srivastava <adityasrivastava301199@gmail.com>