### PR TITLE
Update expanduser to work with windows

### DIFF
--- a/hub/store/lru_cache.py
+++ b/hub/store/lru_cache.py
@@ -3,23 +3,8 @@ from collections.abc import MutableMapping
 
 # from multiprocessing import Lock
 
-import fcntl
 import hashlib
 import uuid
-
-
-class SystemMutex:
-    def __init__(self, name=str(uuid.uuid4())):
-        self.name = name
-        self._lockid = hashlib.sha1(self.name.encode("utf8")).hexdigest()
-
-    def __enter__(self):
-        self.fp = open(f"/tmp/.lock-{self._lockid}.lck", "wb")
-        fcntl.flock(self.fp.fileno(), fcntl.LOCK_EX)
-
-    def __exit__(self, _type, value, tb):
-        fcntl.flock(self.fp.fileno(), fcntl.LOCK_UN)
-        self.fp.close()
 
 
 class DummyLock:

--- a/hub/store/store.py
+++ b/hub/store/store.py
@@ -98,7 +98,8 @@ def _get_storage_map(fs, path):
 
 def get_storage_map(fs, path, memcache=2 ** 26, lock=True, storage_cache=2 ** 28):
     store = _get_storage_map(fs, path)
-    cache_path = posixpath.expanduser(posixpath.join("~/.activeloop/cache/", path))
+    cache_path = os.path.expanduser(posixpath.join("~/.activeloop/cache/", path))
+    print(cache_path)
     if storage_cache and storage_cache > 0:
         os.makedirs(cache_path, exist_ok=True)
         store = LRUCache(

--- a/hub/store/store.py
+++ b/hub/store/store.py
@@ -96,10 +96,32 @@ def _get_storage_map(fs, path):
     return StorageMapWrapperWithCommit(fs.get_mapper(path, check=False, create=False))
 
 
+def get_cache_path(path, cache_folder="~/.activeloop/cache/"):
+    if (
+        path.startswith("s3://")
+        or path.startswith("gcs://")
+    ):
+        path = '//'.join(path.split("//")[1:])
+    elif (
+        path.startswith("../")
+        or path.startswith("./")
+        or path.startswith("/")
+        or path.startswith("~/")
+    ):
+        path = "/".join(path.split("/")[1:])
+    elif path.find("://") != -1:
+        path = path.split("://")[-1]
+    elif path.find(":\\") != -1:
+        path = path.split(":\\")[-1]
+    else:
+        # path is username/dataset or username/dataset:version
+        path = path.replace(':', '/')
+    return os.path.expanduser(posixpath.join(cache_folder, path))
+
+
 def get_storage_map(fs, path, memcache=2 ** 26, lock=True, storage_cache=2 ** 28):
     store = _get_storage_map(fs, path)
-    cache_path = os.path.expanduser(posixpath.join("~/.activeloop/cache/", path))
-    print(cache_path)
+    cache_path = get_cache_path(path)
     if storage_cache and storage_cache > 0:
         os.makedirs(cache_path, exist_ok=True)
         store = LRUCache(

--- a/hub/store/tests/test_store.py
+++ b/hub/store/tests/test_store.py
@@ -1,0 +1,16 @@
+from hub.store.store import get_cache_path
+
+
+def test_get_cache_path():
+    cache_folder = './cache/'
+    assert "./cache/test/testdb" == get_cache_path('s3://test/testdb', cache_folder)      
+    assert "./cache/test/testdb" == get_cache_path('gcs://test/testdb', cache_folder)
+    assert "./cache/test/testdb" == get_cache_path('test/testdb', cache_folder)
+    assert "./cache/test/testdb" == get_cache_path('https://test/testdb', cache_folder)
+    assert "./cache/test/testdb" == get_cache_path('~/test/testdb', cache_folder)
+    assert "./cache/test/testdb" == get_cache_path('/test/testdb', cache_folder)
+    assert "./cache/test\\testdb" == get_cache_path('C:\\test\\testdb', cache_folder)
+
+
+if __name__ == "__main__":
+    test_get_cache_path()


### PR DESCRIPTION
fixes #217 and fixes #215 
 
The first patch updates the posixpath expanduser to use os.path.expanduser which works on both windows and Linux (posix like os). Also removes the fnctl and system mutex class as they are not being used and cause problems in Windows.

The second patch fixes the cache path in all OS and envs (s3, gcs, https, windows, posix, etc)

Tested on new AWS Windows Machine.


Signed-off-by: Aditya Srivastava <adityasrivastava301199@gmail.com>