### PR TITLE
Small change to fix the issue.

### DIFF
--- a/hub/api/dataset.py
+++ b/hub/api/dataset.py
@@ -531,7 +531,6 @@ class Dataset:
         for t in self._tensors.values():
             t.flush()
         self._fs_map.flush()
-        self._update_dataset_state()
 
     def commit(self):
         """ Deprecated alias to flush()"""


### PR DESCRIPTION
@Diveafall @AbhinavTuli #285 
Not to work properly .close must be executed when the user is done with the database. Waiting for fix on the backend side, so this is no longer the case. Backend should be able to not only create but also update the state of the dataset in the database.
