### PR TITLE
Gives error when both shape and max_shape are none

### DIFF
--- a/hub/schema/features.py
+++ b/hub/schema/features.py
@@ -125,6 +125,8 @@ class Tensor(HubSchema):
             Sample Count is also in the list of tensor's dimensions (first dimension)
             If default value is chosen, automatically detects how to split into chunks
         """
+        if shape is None or shape == (None,) and max_shape is None:
+            raise TypeError("both shape and max_shape cannot be None at the same time")
         shape = (shape,) if isinstance(shape, int) else tuple(shape)
         chunks = _normalize_chunks(chunks)
         max_shape = max_shape or shape

--- a/hub/schema/tests/test_tensor.py
+++ b/hub/schema/tests/test_tensor.py
@@ -1,6 +1,14 @@
+from typing import Type
 from hub.schema import Tensor, Image, Primitive
 from hub.schema.features import flatten
 import pytest
+
+
+def test_tensor_error():
+    try:
+        Tensor(None, max_shape=None)
+    except TypeError as ex:
+        assert "both shape and max_shape cannot be None at the same time" in str(ex)
 
 
 def test_tensor_flattening():
@@ -38,20 +46,16 @@ def test_primitive_repr():
 
 def test_tensor_init():
     with pytest.raises(ValueError):
-        tensor_object = Tensor(shape=2, max_shape=(2, 2))
+        Tensor(shape=2, max_shape=(2, 2))
 
 
 def test_tensor_str():
-    tensor_object = Tensor()
     tensor_object_2 = Tensor(shape=(5000,), dtype="<U20")
-    assert tensor_object.__str__() == "Tensor(shape=(None,), dtype='float64')"
     assert tensor_object_2.__str__() == "Tensor(shape=(5000,), dtype='<U20')"
 
 
 def test_tensor_repr():
-    tensor_object = Tensor()
     tensor_object_2 = Tensor(shape=(5000,), dtype="<U20")
-    assert tensor_object.__repr__() == "Tensor(shape=(None,), dtype='float64')"
     assert tensor_object_2.__repr__() == "Tensor(shape=(5000,), dtype='<U20')"
 
 

--- a/hub/store/dynamic_tensor.py
+++ b/hub/store/dynamic_tensor.py
@@ -68,6 +68,8 @@ class DynamicTensor:
             shape = shapeDt.shape
             max_shape = shapeDt.max_shape
             chunks = shapeDt.chunks
+        elif "r" not in mode:
+            raise TypeError("shape cannot be none")
 
         self.fs_map = fs_map
         exist_ = fs_map.get(".hub.dynamic_tensor")

--- a/hub/store/tests/test_dynamic_tensor.py
+++ b/hub/store/tests/test_dynamic_tensor.py
@@ -1,3 +1,4 @@
+from hub.exceptions import DynamicTensorShapeException
 import posixpath
 
 import numpy as np
@@ -52,6 +53,17 @@ def test_dynamic_tensor():
     )
     t[0, 80:, 80:] = np.ones((20, 20), dtype="int32")
     assert t[0, -5, 90:].tolist() == [1] * 10
+
+
+def test_dynamic_tensor_shape_none():
+    try:
+        DynamicTensor(
+            create_store("./data/test/test_dynamic_tensor_shape_none"),
+            mode="w",
+            dtype="int32",
+        )
+    except TypeError as ex:
+        assert "shape cannot be none" in str(ex)
 
 
 def test_dynamic_tensor_2():


### PR DESCRIPTION
Gives error when both shape and max_shape are none.
Solved issue when the program unexpectedly crashes without User readable error, because of wrong user input. 