### PR TITLE
Fixes to transform to properly support cases such as np.array("abc")

### DIFF
--- a/hub/api/objectview.py
+++ b/hub/api/objectview.py
@@ -1,6 +1,6 @@
 from hub.api.datasetview import DatasetView
 from hub.schema import Sequence, Tensor, SchemaDict, Primitive
-from hub.api.dataset_utils import slice_extract_info, slice_split, str_to_int
+from hub.api.dataset_utils import get_value, slice_extract_info, slice_split, str_to_int
 
 # from hub.exceptions import NoneValueException
 import collections.abc as abc
@@ -260,7 +260,7 @@ class ObjectView:
             objview = self
         else:
             objview = self.__getitem__(slice_)
-        assign_value = value
+        assign_value = get_value(value)
 
         if not isinstance(objview.dataset, DatasetView):
             # subpath present but no slice done

--- a/hub/compute/ray.py
+++ b/hub/compute/ray.py
@@ -7,7 +7,7 @@ from typing import Iterable, Iterator
 from hub.exceptions import ModuleNotInstalledException
 from hub.api.sharded_datasetview import ShardedDatasetView
 import hub
-from hub.api.dataset_utils import str_to_int
+from hub.api.dataset_utils import get_value, str_to_int
 
 
 def empty_remote(template, **kwargs):
@@ -203,6 +203,7 @@ class RayTransform(Transform):
         for key, value in results.items():
 
             length = ds[key].chunksize[0]
+            value = get_value(value)
             value = str_to_int(value, ds.tokenizer)
             batched_values = batchify(value, length)
             chunk_id = list(range(len(batched_values)))

--- a/hub/compute/tests/test_transform.py
+++ b/hub/compute/tests/test_transform.py
@@ -246,6 +246,19 @@ def test_stacked_transform():
     assert (ds4["test", 0].compute() == 30 * np.ones((2, 2))).all()
 
 
+def test_text():
+    my_schema = {"text": Text((None,), max_shape=(10,))}
+
+    @hub.transform(schema=my_schema)
+    def my_transform(sample):
+        return {"text": np.array("abc")}
+
+    ds = my_transform([i for i in range(10)])
+    ds2 = ds.store("./data/test/transform_text")
+    for i in range(10):
+        assert ds2["text", i].compute() == "abc"
+
+
 def test_zero_sample_transform():
     schema = {"test": Tensor((None, None), dtype="uint8", max_shape=(10, 10))}
 

--- a/hub/compute/transform.py
+++ b/hub/compute/transform.py
@@ -6,7 +6,7 @@ from hub.api.dataset import Dataset
 from tqdm import tqdm
 from collections.abc import MutableMapping
 from hub.utils import batchify
-from hub.api.dataset_utils import slice_extract_info, slice_split, str_to_int
+from hub.api.dataset_utils import get_value, slice_extract_info, slice_split, str_to_int
 import collections.abc as abc
 from hub.api.datasetview import DatasetView
 from pathos.pools import ProcessPool, ThreadPool
@@ -277,7 +277,9 @@ class Transform:
 
             chunk = ds[key].chunksize[0]
             chunk = 1 if chunk == 0 else chunk
+            value = get_value(value)
             value = str_to_int(value, ds.dataset.tokenizer)
+
             num_chunks = math.ceil(len(value) / (chunk * self.workers))
             length = num_chunks * chunk if self.workers != 1 else len(value)
             batched_values = batchify(value, length)


### PR DESCRIPTION
Adding get_value before str_to_int, to handle cases like np.array("abc")