### PR TITLE
Faster pytorch dataset with current chunk logic

### DIFF
--- a/benchmarks/benchmark_to_pytorch.py
+++ b/benchmarks/benchmark_to_pytorch.py
@@ -1,3 +1,5 @@
+from time import time
+
 import torchvision
 import torch
 import numpy as np
@@ -23,7 +25,7 @@ class HubAdapter2(torch.utils.data.Dataset):
 
     def __getitem__(self, index):
         x, y = self.ds.__getitem__(index)
-        res = {"image": np.array(x), "label": y}
+        res = {"label": y}
         return res
 
 
@@ -37,16 +39,19 @@ def test():
     hub_s3_ds = hub.Dataset(
         url="./data/test/cifar/train", cache=False, storage_cache=False
     )
-    print(hub_s3_ds._tensors["/image"].chunks)
+    for key, value in hub_s3_ds._tensors.items():
+        print(key, value.shape, value.chunks)
     hub_s3_ds = hub_s3_ds.to_pytorch()
-    dl = torch.utils.data.DataLoader(hub_s3_ds, batch_size=100, num_workers=8)
+    dl = torch.utils.data.DataLoader(hub_s3_ds, batch_size=10, num_workers=0)
     with Timer("Time"):
         counter = 0
+        t0 = time()
         for i, b in enumerate(dl):
-            with Timer("Batch Time"):
-                x, y = b["image"], b["image"]
-                counter += 100
-                print(counter)
+            x, y = b["label"], b["label"]
+            counter += 100
+            t1 = time()
+            print(counter, f"dt: {t1 - t0}")
+            t0 = t1
 
 
 if __name__ == "__main__":

--- a/hub/api/dataset.py
+++ b/hub/api/dataset.py
@@ -21,8 +21,6 @@ from hub.schema.features import (
 )
 from hub.log import logger
 
-# from hub.api.tensorview import TensorView
-# from hub.api.datasetview import DatasetView
 from hub.api.objectview import ObjectView, DatasetView
 from hub.api.tensorview import TensorView
 from hub.api.dataset_utils import (
@@ -1163,7 +1161,7 @@ class TorchDataset:
                 if split_key[i] not in cur.keys():
                     cur[split_key[i]] = {}
                 cur = cur[split_key[i]]
-            # item = self._ds._tensors[key][index]
+
             item = self._get_active_item(key, index)
             if not isinstance(item, bytes) and not isinstance(item, str):
                 t = item

--- a/hub/api/dataset.py
+++ b/hub/api/dataset.py
@@ -1114,6 +1114,7 @@ class TorchDataset:
         self.output_type = output_type
         self.num_samples = num_samples
         self.offset = offset
+        self._inited = False
 
     def _do_transform(self, data):
         return self._transform(data) if self._transform else data
@@ -1124,10 +1125,32 @@ class TorchDataset:
         """
         if self._ds is None:
             self._ds = Dataset(self._url, token=self._token, lock_cache=False)
+        if not self._inited:
+            self._inited = True
+            self._samples_in_chunks = {
+                key: (None in value.shape) and 1 or value.chunks[0]
+                for key, value in self._ds._tensors.items()
+            }
+            self._active_chunks = {}
+            self._active_chunks_range = {}
 
     def __len__(self):
         self._init_ds()
         return self.num_samples if self.num_samples is not None else self._ds.shape[0]
+
+    def _get_active_item(self, key, index):
+        active_range = self._active_chunks_range.get(key)
+        samples_per_chunk = self._samples_in_chunks[key]
+        if active_range is None or index not in active_range:
+            active_range_start = index - index % samples_per_chunk
+            active_range = range(
+                active_range_start, active_range_start + samples_per_chunk
+            )
+            self._active_chunks_range[key] = active_range
+            self._active_chunks[key] = self._ds._tensors[key][
+                active_range.start : active_range.stop
+            ]
+        return self._active_chunks[key][index % samples_per_chunk]
 
     def __getitem__(self, index):
         index = index + self.offset if self.offset is not None else index
@@ -1140,10 +1163,10 @@ class TorchDataset:
                 if split_key[i] not in cur.keys():
                     cur[split_key[i]] = {}
                 cur = cur[split_key[i]]
-            if not isinstance(self._ds._tensors[key][index], bytes) and not isinstance(
-                self._ds._tensors[key][index], str
-            ):
-                t = self._ds._tensors[key][index]
+            # item = self._ds._tensors[key][index]
+            item = self._get_active_item(key, index)
+            if not isinstance(item, bytes) and not isinstance(item, str):
+                t = item
                 if self.inplace:
                     t = torch.tensor(t)
                 cur[split_key[-1]] = t

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import os
 from setuptools import find_packages, setup
 
 project = "hub"
-VERSION = "1.0.7"
+VERSION = "1.0.9"
 
 this_directory = os.path.abspath(os.path.dirname(__file__))
 with open(os.path.join(this_directory, "README.md")) as f:


### PR DESCRIPTION
Each process of data loader remembers the current chunk in python memory and uses it as a cache. This enabled us to skip huge pythonic overhead thus improving performance. 
This still does not work for dynamic tensors because we cannot request a multisample slice from datasets with dynamic tensors.