### PR TITLE
add README Badge Section in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,16 @@ Activeloop’s Hub format lets you achieve faster inference at a lower cost. We 
 
 Check these and many more popular datasets on our [visualizer web app](https://app.activeloop.ai/datasets/popular) and load them directly for model training!
 
+## README Badge
+
+Using Hub? Add a README badge to let everyone know: 
+
+
+[![hub](https://img.shields.io/badge/powered%20by-hub%20-ff5a1f.svg)](https://github.com/activeloopai/Hub)
+
+```
+[![hub](https://img.shields.io/badge/powered%20by-hub%20-ff5a1f.svg)](https://github.com/activeloopai/Hub)
+```
 
 ## Disclaimers
 


### PR DESCRIPTION
Add the README Badge/Shield in the README.md

Question: Shall we put it as: `powered by Hub` OR `powered by activeloop.ai`?
Also, what should it redirect to when clicked? I will make necessary changes.

Currently, it says: `powered by Hub` and redirects to the Hub repository (as most python libs do).
