### PR TITLE
Add link in Code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at . All
+reported by contacting the project team [here](abuse-aaaac6iqyos7eajwguyhxrq4zm@hubdb.slack.com). All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.

--- a/README.md
+++ b/README.md
@@ -180,7 +180,6 @@ Check these and many more popular datasets on our [visualizer web app](https://a
 
 Using Hub? Add a README badge to let everyone know: 
 
-
 [![hub](https://img.shields.io/badge/powered%20by-hub%20-ff5a1f.svg)](https://github.com/activeloopai/Hub)
 
 ```


### PR DESCRIPTION
There was a missing link in CODE_OF_CONDUCT.md file.

It has been added in this PR. Solves the issue #422 

