### PR TITLE
ci: Fixes CI deployment pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ workflows:
   test:
     jobs:
       - test:
-          context: 
+          context:
             - test
             - azure
       - test_full:
@@ -19,7 +19,7 @@ workflows:
   test_and_deploy:
     jobs:
       - test:
-          context:  
+          context:
             - test
             - azure
           filters:
@@ -28,7 +28,7 @@ workflows:
             branches:
               ignore: /.*/
       - test_full:
-          context:  
+          context:
             - test
             - azure
           filters:
@@ -37,7 +37,7 @@ workflows:
             branches:
               ignore: /.*/
       - deploy:
-          context: 
+          context:
             - pypi
             - snark-docker
           requires:
@@ -143,7 +143,7 @@ jobs:
       - run:
           name: "Upload dist to PyPi"
           command: |
-            twine upload dist/*
+            twine upload --skip-existing dist/*
       - run:
           name: "Build Docker Hub Image"
           command: |
@@ -159,4 +159,3 @@ jobs:
       - slack/status:
           fail_only: true
           webhook: $SLACK_WEBHOOK
-


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### All Submissions:

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
- [ ] Is your [Pull Requests](../../../pulls) linked to an [Issue](../../../issues)

### What does this PR do?

This PR fixes [twine upload pipeline](https://app.circleci.com/pipelines/github/activeloopai/Hub/1025/workflows/7060ecf1-0a4c-458d-8276-36ebdde2a297/jobs/1083) via adding `--skip-existing` tag to prevent version conflict.
This PR also remove some trailing spaces, newlines in `.circleci/config.yml`.

### Notes
This PR will take effect on next tag release.

Currently PyPi doesn't allow package override and lead to `400 File already exists.` Although using build number for wheel versioning the wheel release succeeded, I got `400 Only one sdist may be uploaded per release.` when releasing sdist distribution.

Considered about [Semantic Versioning](https://semver.org/lang/zh-TW/), maybe release a newer version to fix bugs is more appropriate than overriding the old version.  Therefore in `config.yml` I added `--skip-existing` to skip if current version exists rather than appending build numbers to override it.