### PR TITLE
Fix typo in benchmarks.md

### DIFF
--- a/docs/source/benchmarks.md
+++ b/docs/source/benchmarks.md
@@ -4,7 +4,7 @@ For full reproducibility please refer to the [code](/test/benchmark)
 
 ### Download Parallelism
 
-The following chart shows that hub on a single machine (aws p3.2xlarge) can achieve up to 875 MB/s download speed with multithreading and multiprocessing enabled. Choosing the chunk size plays a role in reaching maximum speed up. The bellow chart shows the tradeoff using different number of threads and processes.
+The following chart shows that hub on a single machine (aws p3.2xlarge) can achieve up to 875 MB/s download speed with multithreading and multiprocessing enabled. Choosing the chunk size plays a role in reaching maximum speed up. The chart below shows the tradeoff using different number of threads and processes.
 
 <img src="https://raw.githubusercontent.com/snarkai/Hub/master/test/benchmark/results/Parallel12MB.png" width="650"/>
 


### PR DESCRIPTION
Changed typo "bellow" to "below", and moved the preposition after the noun. For more on why this is the gramatically correct order, see [this english stackexchange post](https://english.stackexchange.com/questions/609/which-is-correct-the-below-information-or-the-information-below)