### PR TITLE
Fixes docker build issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,6 +124,7 @@ jobs:
     environment:
       IMAGE_NAME: snarkai/hub
     steps:
+      - setup_remote_docker
       - checkout
       - run:
           name: "Init .pypirc"


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### All Submissions:

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
- [x] Is your [Pull Requests](../../../pulls) linked to an [Issue](../../../issues)

### What does this PR do?
Fixes #367, since the docker build step fails the issue exists.

### Details
According to [CircleCI document](https://circleci.com/docs/2.0/building-docker-images/), the build step have to add `- setup_remote_docker` for security reasons.