### PR TITLE
Store dataset name in meta.json

### DIFF
--- a/hub/api/dataset.py
+++ b/hub/api/dataset.py
@@ -494,6 +494,7 @@ class Dataset:
         self.resize_shape(size)
 
     def rename(self, name: str) -> None:
+        """ Renames the dataset """
         self._name = name
         self.meta = self._store_meta()
         self.flush()

--- a/hub/api/tests/test_dataset.py
+++ b/hub/api/tests/test_dataset.py
@@ -648,6 +648,20 @@ def test_dataset_assign_value():
     assert ds["text", 6].compute() == "YGFJN75NF"
 
 
+def test_dataset_name():
+    schema = {"temp": "uint8"}
+    ds = Dataset(
+        "./data/test_ds_name", shape=(10,), schema=schema, name="my_dataset", mode="w"
+    )
+    ds.flush()
+    assert ds.name == "my_dataset"
+    ds2 = Dataset("./data/test_ds_name")
+    ds2.rename("my_dataset_2")
+    assert ds2.name == "my_dataset_2"
+    ds3 = Dataset("./data/test_ds_name")
+    assert ds3.name == "my_dataset_2"
+
+
 if __name__ == "__main__":
     # test_pickleability()
     test_pickleability()


### PR DESCRIPTION
Users can now specify dataset name at the time of creation. This is only useful for the visualizer and is irrelevant for datasets not stored on hub storage:-
```python
ds = hub.Dataset("username/dataset_url", schema=my_schema,  shape=(10,), name="my_dataset")
```
Dataset owners can also rename the dataset:-
```python
ds2 = hub.Dataset("username/dataset_url")
ds2.rename("new_name")
```
You can check the dataset name using:-
```python
print(ds.name)
```