### PR TITLE
Evaluate multiple arguments using pytest parameterized

### DIFF
--- a/hub/schema/tests/test_features.py
+++ b/hub/schema/tests/test_features.py
@@ -107,10 +107,15 @@ def test_mask():
     with pytest.raises(ValueError):
         mask2 = Mask(shape=(11, 4, 2))
 
+test_image_inputs = [
+  "uint32", "int16", "float32", "float64", "int8", "int16", "int32", "double"
+]
 
-def test_image():
+@pytest.mark.parametrize('test_image', test_image_inputs)
+
+def test_image(test_image):
     with pytest.raises(ValueError):
-        image = Image((1920, 1080, 3), "float32")
+        image = Image((1920, 1080, 3), test_image)
 
 
 def test_audio():

--- a/hub/schema/tests/test_features.py
+++ b/hub/schema/tests/test_features.py
@@ -116,7 +116,7 @@ test_image_inputs = [
     "int8",
     "int16",
     "int32",
-    "double"
+    "double",
 ]
 
 

--- a/hub/schema/tests/test_features.py
+++ b/hub/schema/tests/test_features.py
@@ -109,11 +109,18 @@ def test_mask():
 
 
 test_image_inputs = [
-    "uint32", "int16", "float32", "float64", "int8", "int16", "int32", "double"
+    "uint32",
+    "int16",
+    "float32",
+    "float64",
+    "int8",
+    "int16",
+    "int32",
+    "double"
 ]
 
 
-@pytest.mark.parametrize('test_image', test_image_inputs)
+@pytest.mark.parametrize("test_image", test_image_inputs)
 def test_image(test_image):
     with pytest.raises(ValueError):
         image = Image((1920, 1080, 3), test_image)

--- a/hub/schema/tests/test_features.py
+++ b/hub/schema/tests/test_features.py
@@ -108,7 +108,7 @@ def test_mask():
         mask2 = Mask(shape=(11, 4, 2))
 
 test_image_inputs = [
-  "uint32", "int16", "float32", "float64", "int8", "int16", "int32", "double"
+    "uint32", "int16", "float32", "float64", "int8", "int16", "int32", "double"
 ]
 
 @pytest.mark.parametrize('test_image', test_image_inputs)

--- a/hub/schema/tests/test_features.py
+++ b/hub/schema/tests/test_features.py
@@ -107,12 +107,13 @@ def test_mask():
     with pytest.raises(ValueError):
         mask2 = Mask(shape=(11, 4, 2))
 
+
 test_image_inputs = [
     "uint32", "int16", "float32", "float64", "int8", "int16", "int32", "double"
 ]
 
-@pytest.mark.parametrize('test_image', test_image_inputs)
 
+@pytest.mark.parametrize('test_image', test_image_inputs)
 def test_image(test_image):
     with pytest.raises(ValueError):
         image = Image((1920, 1080, 3), test_image)


### PR DESCRIPTION
This is an initial attempt to improve test coverage by evaluating multiple arguments. This is achieved by using `@pytest.mark.parameterized` .

Currently the dtypes being tested are:
`uint32`, `int16`, `float32`, `float64`, `int8`, `int16`, `int32`, `double`

And the following are skipped for now:
`uint8`, `uint16`