### PR TITLE
Replaced commit() with flush() in documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ ds = Dataset(
 
 ds["image"][:] = np.zeros((4, 512, 512))
 ds["label"][:] = np.zeros((4, 512, 512))
-ds.commit()
+ds.flush()
 ```
 
 3. Access it from anywhere else in the world, on any device having a command line:

--- a/README_CN.md
+++ b/README_CN.md
@@ -109,7 +109,7 @@ ds = Dataset(
 # filling the data containers with data (here - zeroes to initialize)
 ds["image"][:] = np.zeros((4, 512, 512))
 ds["label"][:] = np.zeros((4, 512, 512))
-ds.commit()  # executing the creation of the dataset
+ds.flush()  # executing the creation of the dataset
 ```
 
 您也可以指明 `s3://bucket/path`, `gcs://bucket/path` 或 azure 路径。您可以在[这里](https://docs.activeloop.ai/en/latest/simple.html#data-storage)找到云储存的更多相关信息。
@@ -141,7 +141,7 @@ ds = Dataset(
 
 ds["image"][:] = np.zeros((4, 512, 512))
 ds["label"][:] = np.zeros((4, 512, 512))
-ds.commit()
+ds.flush()
 ```
 
 3. 在任何地点，以任何机器，只要有命令行就可访问它：

--- a/docs/source/concepts/dataset.md
+++ b/docs/source/concepts/dataset.md
@@ -27,7 +27,7 @@ To add data to the dataset:
 ```python
 ds["image"][:] = np.ones((4, 512, 512))
 ds["label"][:] = np.ones((4, 512, 512))
-ds.commit()
+ds.flush()
 ```
 
 ## Load the data

--- a/docs/source/simple.md
+++ b/docs/source/simple.md
@@ -105,7 +105,7 @@ This code creates dataset in *"./data/examples/new_api_intro"* folder with overw
 After this we can loop over dataset and read/write from it.
 
 
-### Why commit?
+### Why flush?
 
 Since caching is in place, you need to tell the program to push final changes to a permanent storage. 
 

--- a/docs/source/tutorials/new_api.md
+++ b/docs/source/tutorials/new_api.md
@@ -52,7 +52,7 @@ for i in range(len(ds)):
 
 print(ds["image", 5].numpy())
 print(ds["label", 100:110].numpy())
-ds.commit()
+ds.flush()
 ```
 
 4) Transferring from TFSDS
@@ -75,7 +75,7 @@ This code creates dataset in *"./data/examples/new_api_intro"* folder with overw
 After this we can loop over dataset and read/write from it.
 
 
-### **Why commit?**
+### **Why flush?**
 
 Since caching is in place, you need to tell program to push final changes to permanent storage. 
 

--- a/examples/Use_Case_DL_crop_yield_prediction_dataset_with_Activeloop.ipynb
+++ b/examples/Use_Case_DL_crop_yield_prediction_dataset_with_Activeloop.ipynb
@@ -2827,7 +2827,7 @@
         "# Upload Data\n",
         "ds[\"histograms\"][:] = histograms_combined\n",
         "ds[\"yields\"][:] = yield_values_linked_hists\n",
-        "ds.commit()\n",
+        "ds.flush()\n",
         "\n",
         "# Load the data\n",
         "print(\"Load data...\")\n",

--- a/examples/basic.py
+++ b/examples/basic.py
@@ -20,7 +20,7 @@ def main():
     # Upload Data
     ds["image"][:] = np.ones((4, 512, 512))
     ds["label"][:] = np.ones((4, 512, 512))
-    ds.commit()
+    ds.flush()
 
     # Load the data
     ds = Dataset(tag)

--- a/examples/big_image.py
+++ b/examples/big_image.py
@@ -25,7 +25,7 @@ def main():
             (2048, 2048, 4), dtype="uint8"
         )  # single chunk read/write
         print(ds._tensors["/image"].get_shape((3,)))
-        ds.commit()
+        ds.flush()
 
 
 if __name__ == "__main__":

--- a/examples/large_dataset_build.py
+++ b/examples/large_dataset_build.py
@@ -21,7 +21,7 @@ def create_large_dataset():
 
     for i in range(len(ds) // 10):
         ds["image", i * 10 : i * 10 + 10] = i * array
-    ds.commit()
+    ds.flush()
 
     ds = hub.Dataset("./data/examples/large_dataset_build")
     print(ds.keys, ds["image"].shape, ds["image"].dtype)

--- a/examples/mnist_upload_speed_benchmark.py
+++ b/examples/mnist_upload_speed_benchmark.py
@@ -30,7 +30,7 @@ def main():
             # with Timer(f"Sample {i}"):
             ds["image", i : i + step] = arr
 
-        ds.commit()
+        ds.flush()
 
 
 if __name__ == "__main__":

--- a/examples/new_api_intro.py
+++ b/examples/new_api_intro.py
@@ -23,7 +23,7 @@ def main():
     print(ds.shape)
     print(ds["label", 100:110].numpy())
     with Timer("Committing"):
-        ds.commit()
+        ds.flush()
 
     ds = Dataset(path)
     print(ds.schema)

--- a/hub/api/dataset.py
+++ b/hub/api/dataset.py
@@ -656,6 +656,7 @@ class Dataset:
 
     def commit(self):
         """ Deprecated alias to flush()"""
+        logger.warning("commit() is deprecated. Use flush() instead")
         self.flush()
 
     def close(self):


### PR DESCRIPTION
Following up on a conversation with @AbhinavTuli and @mynameisvinn, I am creating a pull request to replace all mentions of `commit()` with `flush()`, as the `commit()` method is deprecated. Please let me know if I've missed anything or need to further replace anything else. Thank you!