### PR TITLE
change ds.commit() to ds.flush() in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ ds = Dataset(
 # filling the data containers with data (here - zeroes to initialize)
 ds["image"][:] = np.zeros((4, 512, 512))
 ds["label"][:] = np.zeros((4, 512, 512))
-ds.commit()  # executing the creation of the dataset
+ds.flush()  # executing the creation of the dataset
 ```
 
 You can also specify `s3://bucket/path`, `gcs://bucket/path` or azure path. [Here](https://docs.activeloop.ai/en/latest/simple.html#data-storage) you can find more information on cloud storage.


### PR DESCRIPTION
Changed `ds.commit()` to `ds.flush()` in README.md due to deprecation warning.