### PR TITLE
Turned reporting off when tests are run

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,10 @@
+import pytest
+
+from humbug.consent import HumbugConsent
+
+from hub.report import hub_reporter
+
+
+@pytest.fixture(scope="session", autouse=True)
+def reporting_off():
+    hub_reporter.consent = HumbugConsent(False)

--- a/hub/report.py
+++ b/hub/report.py
@@ -8,7 +8,7 @@ import os
 import json
 import uuid
 
-from humbug.consent import HumbugConsent, environment_variable_opt_out
+from humbug.consent import HumbugConsent
 from humbug.report import Reporter
 
 from hub.config import (


### PR DESCRIPTION
Did this by creating a session-level autouse Pytest fixture in `conftest.py` (at project root).

Removed unused import in `hub/report.py`.