### PR TITLE
Fixed README  links

### DIFF
--- a/README_translations/README_CN.md
+++ b/README_translations/README_CN.md
@@ -31,7 +31,7 @@
 
 ---
 
-[ [English](./README.md) | 简体中文 | [Türkçe](./README_TR.md) | [한글](./README_KR.md)]
+[ [English](../README.md) | [Français](./README_FR.md) | 简体中文 | [Türkçe](./README_TR.md) | [한글](./README_KR.md) | [Bahasa Indonesia](./README_ID.md)]
 
 ### Hub 的作用是什么?
 

--- a/README_translations/README_FR.md
+++ b/README_translations/README_FR.md
@@ -31,7 +31,7 @@
 
 ---
 
-[ English | [简体中文](./README_CN.md) | [Türkçe](./README_TR.md) | [한글](./README_KR.md) | [Français](./READE_FR.md)]
+[ [English](../README.md) | Français | [简体中文](./README_CN.md) | [Türkçe](./README_TR.md) | [한글](./README_KR.md) | [Bahasa Indonesia](./README_ID.md)]
 
 ### À quoi sert Hub ?
 

--- a/README_translations/README_ID.md
+++ b/README_translations/README_ID.md
@@ -31,7 +31,7 @@
 
 ---
 
-[ English | [Français](./README_FR.md) | [简体中文](./README_CN.md) | [Türkçe](./README_TR.md) | [한글](./README_KR.md) | [Bahasa Indonesia](./README_ID.md)]
+[ [English](../README.md) | [Français](./README_FR.md) | [简体中文](./README_CN.md) | [Türkçe](./README_TR.md) | [한글](./README_KR.md) | Bahasa Indonesia ]
 
 <i>Perhatian: translasi ini mungkin bukan berasal dari dokumen yang paling baru</i>
 

--- a/README_translations/README_KR.md
+++ b/README_translations/README_KR.md
@@ -31,7 +31,7 @@
 
 ---
 
-[ [English](./README.md) | [简体中文](./README_CN.md) | [Türkçe](./README_TR.md) | 한글]
+[ [English](../README.md) | [Français](./README_FR.md) | [简体中文](./README_CN.md) | [Türkçe](./README_TR.md) | 한글 | [Bahasa Indonesia](./README_ID.md)]
 
 ### Hub는 무엇인가요?
 

--- a/README_translations/README_TR.md
+++ b/README_translations/README_TR.md
@@ -30,7 +30,7 @@
 
 ---
 
-[ [English](./README.md) | [简体中文](./README_CN.md) | Türkçe | [한글](./README_KR.md)]
+[ [English](../README.md) | [Français](./README_FR.md) | [简体中文](./README_CN.md) | Türkçe | [한글](./README_KR.md) | [Bahasa Indonesia](./README_ID.md)]
 
 ### Hub ne içindir?
 


### PR DESCRIPTION
Simply changed the broken hyperlinks in the markdown files and rearranged the order of languages in some of the READMEs for uniformity. Closes #681 