### PR TITLE
Added tags to usage and crash reports

### DIFF
--- a/hub/cli/auth.py
+++ b/hub/cli/auth.py
@@ -13,7 +13,7 @@ from hub import config
 from hub.client.auth import AuthClient
 from hub.client.token_manager import TokenManager
 from hub.client.hub_control import HubControlClient
-from hub.report import configure_reporting, get_reporting_config, hub_reporter
+from hub.report import configure_reporting, get_reporting_config, hub_reporter, hub_tags
 
 
 @click.command()
@@ -79,7 +79,7 @@ def reporting(on):
     """
     report = Report(
         title="Consent change",
-        tags=hub_reporter.system_tags(),
+        tags=hub_reporter.system_tags() + hub_tags,
         content="Consent? `{}`".format(on),
     )
     hub_reporter.publish(report)

--- a/hub/report.py
+++ b/hub/report.py
@@ -98,6 +98,10 @@ hub_reporter = Reporter(
 hub_version_tag = "version:{}".format(hub_version)
 hub_tags = [hub_version_tag]
 
+hub_user = get_reporting_config().get("username")
+if hub_user is not None:
+    hub_tags.append("username:{}".format(hub_user))
+
 
 class ExceptionWithReporting(Exception):
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
This PR adds a `username:<Activeloop username>` tag to usage and crash reports from users who have opted into reporting.