### PR TITLE
Fixed an issue when overwriting transform datasets

### DIFF
--- a/hub/api/dataset.py
+++ b/hub/api/dataset.py
@@ -237,8 +237,10 @@ class Dataset:
                 self._version_node = VersionNode(self._commit_id, self._branch)
                 self._branch_node_map = {self._branch: self._version_node}
                 self._commit_node_map = {self._commit_id: self._version_node}
+                self._chunk_commit_map = {
+                    path: defaultdict(set) for schema, path in self._flat_tensors
+                }
                 self._tensors = dict(self._generate_storage_tensors())
-                self._chunk_commit_map = {key: defaultdict(set) for key in self.keys}
             except Exception as e:
                 try:
                     self.close()

--- a/hub/store/metastore.py
+++ b/hub/store/metastore.py
@@ -3,7 +3,6 @@ License:
 This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
 If a copy of the MPL was not distributed with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
 """
-from collections import defaultdict
 import json
 from collections.abc import MutableMapping
 import posixpath
@@ -125,8 +124,13 @@ class MetaStorage(MutableMapping):
             if self._ds._commit_id:
                 k = self.find_chunk(k) or f"{k}:{self._ds._commit_id}"
             commit_id = k.split(":")[-1]
-            self._ds._chunk_commit_map[self._path][chunk_key].remove(commit_id)
-            del self._fs_map[k]
+            try:
+                self._ds._chunk_commit_map[self._path][chunk_key].remove(commit_id)
+            except Exception:
+                try:
+                    del self._fs_map[k]
+                except Exception:
+                    pass
 
     def flush(self):
         self._meta.flush()


### PR DESCRIPTION
The below code earlier gave an error "AttributeError: 'Dataset' object has no attribute '_chunk_commit_map'"
```python
ds_transform = some_transform(iterable)
ds = ds_transform.store("abcd/ds_name")
ds = ds_transform.store("abcd/ds_name")
```

This has now been fixed.