### PR TITLE
Improvements to to_pytorch

### DIFF
--- a/hub/api/dataset.py
+++ b/hub/api/dataset.py
@@ -709,8 +709,12 @@ class Dataset:
         inplace=True,
         output_type=dict,
         indexes=None,
+        key_list=None,
     ):
         """| Converts the dataset into a pytorch compatible format.
+        ** Pytorch does not support uint16, uint32, uint64 dtypes. These are implicitly type casted to int32, int64 and int64 respectively.
+        Avoid having schema with these dtypes if you want to avoid this implicit conversion.
+        ** This method does not work with Sequence schema
 
         Parameters
         ----------
@@ -721,11 +725,14 @@ class Dataset:
         output_type: one of list, tuple, dict, optional
             Defines the output type. Default is dict - same as in original Hub Dataset.
         indexes: list or int, optional
-            The samples to be converted into tensorflow format. Takes all samples in dataset by default.
+            The samples to be converted into Pytorch format. Takes all samples in dataset by default.
+        key_list: list, optional
+            The list of keys that are needed in Pytorch format. For nested schemas such as {"a":{"b":{"c": Tensor()}}}
+            use ["a/b/c"] as key_list
         """
         from .integrations import _to_pytorch
 
-        ds = _to_pytorch(self, transform, inplace, output_type, indexes)
+        ds = _to_pytorch(self, transform, inplace, output_type, indexes, key_list)
         return ds
 
     def to_tensorflow(self, indexes=None, include_shapes=False, key_list=None):

--- a/hub/api/datasetview.py
+++ b/hub/api/datasetview.py
@@ -267,13 +267,11 @@ class DatasetView:
             indexes=self.indexes, include_shapes=include_shapes, key_list=key_list
         )
 
-    def to_pytorch(
-        self,
-        transform=None,
-        inplace=True,
-        output_type=dict,
-    ):
+    def to_pytorch(self, transform=None, inplace=True, output_type=dict, key_list=None):
         """| Converts the dataset into a pytorch compatible format.
+        ** Pytorch does not support uint16, uint32, uint64 dtypes. These are implicitly type casted to int32, int64 and int64 respectively.
+        Avoid having schema with these dtypes if you want to avoid this implicit conversion.
+        ** This method does not work with Sequence schema
 
         Parameters
         ----------
@@ -289,6 +287,7 @@ class DatasetView:
             indexes=self.indexes,
             inplace=inplace,
             output_type=output_type,
+            key_list=key_list,
         )
 
     def resize_shape(self, size: int) -> None:

--- a/hub/api/tests/test_converters.py
+++ b/hub/api/tests/test_converters.py
@@ -144,6 +144,49 @@ def test_to_tensorflow_key_list():
         tds = dsv.to_tensorflow(key_list=["xyz"])
 
 
+@pytest.mark.skipif(not pytorch_loaded(), reason="requires pytorch to be loaded")
+def test_to_pytorch_key_list():
+    schema = {
+        "abc": {
+            "d": Tensor((100, 100, 3)),
+            "e": Tensor((100, 100, 3)),
+            "f": {"g": Tensor((100, 100, 3))},
+        },
+        "int": "uint32",
+    }
+    ds = hub.Dataset("./data/test_to_pt_key_list", shape=(10,), schema=schema, mode="w")
+    for i in range(10):
+        ds["abc/d", i] = i * np.ones((100, 100, 3))
+        ds["abc/e", i] = i * np.ones((100, 100, 3))
+        ds["abc/f/g", i] = i * np.ones((100, 100, 3))
+        ds["int", i] = i
+    tds = ds.to_pytorch(key_list=["abc/d", "abc/f/g"])
+    for i, item in enumerate(tds):
+        d = item
+        assert list(d.keys()) == ["abc"]
+        d = d["abc"]
+        assert list(d.keys()) == ["d", "f"]
+        d = d["f"]
+        assert list(d.keys()) == ["g"]
+        assert (item["abc"]["d"].numpy() == i * np.ones((100, 100, 3))).all()
+        assert (item["abc"]["f"]["g"].numpy() == i * np.ones((100, 100, 3))).all()
+
+    dsv = ds[5:]
+    tds = dsv.to_pytorch(key_list=["abc/d", "abc/f/g"])
+    for i, item in enumerate(tds):
+        d = item
+        assert list(d.keys()) == ["abc"]
+        d = d["abc"]
+        assert list(d.keys()) == ["d", "f"]
+        d = d["f"]
+        assert list(d.keys()) == ["g"]
+        assert (item["abc"]["d"].numpy() == (i + 5) * np.ones((100, 100, 3))).all()
+        assert (item["abc"]["f"]["g"].numpy() == (i + 5) * np.ones((100, 100, 3))).all()
+
+    with pytest.raises(KeyError):
+        tds = dsv.to_pytorch(key_list=["xyz"])
+
+
 @pytest.mark.skipif(not tensorflow_loaded(), reason="requires tensorflow to be loaded")
 def test_to_from_tensorflow():
     my_schema = {

--- a/hub/api/tests/test_converters.py
+++ b/hub/api/tests/test_converters.py
@@ -187,6 +187,19 @@ def test_to_pytorch_key_list():
         tds = dsv.to_pytorch(key_list=["xyz"])
 
 
+@pytest.mark.skipif(not pytorch_loaded(), reason="requires pytorch to be loaded")
+def test_to_pytorch_dtype_coversion():
+    schema = {
+        "abc": "uint16",
+        "def": "uint32",
+        "ghi": "uint64",
+    }
+    ds = hub.Dataset("./data/ds_type_conversion", schema=schema, shape=(10,))
+    pt_ds = ds.to_pytorch()
+    for item in pt_ds:
+        pass
+
+
 @pytest.mark.skipif(not tensorflow_loaded(), reason="requires tensorflow to be loaded")
 def test_to_from_tensorflow():
     my_schema = {

--- a/hub/schema/class_label.py
+++ b/hub/schema/class_label.py
@@ -128,6 +128,7 @@ class ClassLabel(Tensor):
     def __init__(
         self,
         shape: Tuple[int, ...] = (),
+        dtype="uint8",
         max_shape: Tuple[int, ...] = None,
         num_classes: int = None,
         names: List[str] = None,
@@ -170,7 +171,7 @@ class ClassLabel(Tensor):
         super().__init__(
             shape=shape,
             max_shape=max_shape,
-            dtype="uint16",
+            dtype=dtype,
             chunks=chunks,
             compressor=compressor,
         )

--- a/hub/schema/deserialize.py
+++ b/hub/schema/deserialize.py
@@ -45,6 +45,7 @@ def deserialize(inp):
             if inp["_names"] is not None:
                 return ClassLabel(
                     shape=tuple(inp["shape"]),
+                    dtype=deserialize(inp["dtype"]),
                     names=inp["_names"],
                     chunks=inp["chunks"],
                     compressor=_get_compressor(inp),
@@ -53,6 +54,7 @@ def deserialize(inp):
             else:
                 return ClassLabel(
                     shape=tuple(inp["shape"]),
+                    dtype=deserialize(inp["dtype"]),
                     num_classes=inp["_num_classes"],
                     chunks=inp["chunks"],
                     compressor=_get_compressor(inp),
@@ -67,8 +69,6 @@ def deserialize(inp):
             return Image(
                 shape=tuple(inp["shape"]),
                 dtype=deserialize(inp["dtype"]),
-                # TODO uncomment back when image encoding will be added
-                # encoding_format=inp["encoding_format"],
                 max_shape=tuple(inp["max_shape"]),
                 chunks=inp["chunks"],
                 compressor=_get_compressor(inp),

--- a/hub/schema/tests/test_features.py
+++ b/hub/schema/tests/test_features.py
@@ -98,7 +98,7 @@ def test_class_label():
 
 def test_class_label_2():
     cl1 = ClassLabel(names=["apple", "banana", "cat"])
-    cl2 = ClassLabel((None,), (10,), names=["apple", "banana", "cat"])
+    cl2 = ClassLabel((None,), max_shape=(10,), names=["apple", "banana", "cat"])
     cl3 = ClassLabel((3,), names=["apple", "banana", "cat"])
     my_schema = {"cl1": cl1, "cl2": cl2, "cl3": cl3}
 
@@ -210,8 +210,8 @@ def test_classlabel_repr():
     cl1 = ClassLabel(num_classes=5)
     cl2 = ClassLabel(names=["apple", "orange", "banana"])
 
-    text1 = "ClassLabel(shape=(), dtype='uint16', num_classes=5)"
-    text2 = "ClassLabel(shape=(), dtype='uint16', names=['apple', 'orange', 'banana'], num_classes=3)"
+    text1 = "ClassLabel(shape=(), dtype='uint8', num_classes=5)"
+    text2 = "ClassLabel(shape=(), dtype='uint8', names=['apple', 'orange', 'banana'], num_classes=3)"
     assert cl1.__repr__() == text1
     assert cl2.__repr__() == text2
 


### PR DESCRIPTION
- to_pytorch now supports a new argument that only passes certain tensors to it and speeds up iteration time in case multiple extra tensors are present.
- caching present within to_pytorch has been improved to tensors with dynamic shapes (earlier it was saving only the current sample in the cache)
- changed default dtype of classlabel from uint16 to uint8