### PR TITLE
Fix/2.0/chunk sizes

### DIFF
--- a/hub/constants.py
+++ b/hub/constants.py
@@ -1,7 +1,8 @@
 BYTE_PADDING = b"\0"
 
 # number of bytes per unit
-KB = 1000
+B = 1
+KB = 1000 * B
 MB = 1000 * KB
 GB = 1000 * MB
 

--- a/hub/core/chunk_engine/tests/common.py
+++ b/hub/core/chunk_engine/tests/common.py
@@ -56,6 +56,7 @@ def assert_chunk_sizes(
     complete_chunk_count = 0
     total_chunks = 0
     actual_chunk_lengths = []
+    actual_chunk_names = set()
     for i, entry in enumerate(index_map):
         for j, chunk_name in enumerate(entry["chunk_names"]):
             chunk_key = get_chunk_key(key, chunk_name)
@@ -72,7 +73,9 @@ def assert_chunk_sizes(
                 j,
             )
 
-            actual_chunk_lengths.append(chunk_length)
+            if chunk_name not in actual_chunk_names:
+                actual_chunk_lengths.append(chunk_length)
+                actual_chunk_names.add(chunk_name)
 
             if chunk_length < chunk_size:
                 incomplete_chunk_names.add(chunk_name)
@@ -95,8 +98,8 @@ def assert_chunk_sizes(
     actual_chunk_lengths = np.array(actual_chunk_lengths)
     if len(actual_chunk_lengths) > 1:
         assert np.all(actual_chunk_lengths[:-1] == chunk_size), (
-            "All chunks (except the last one) MUST be == `chunk_size`. chunk_size=%i\n\nactual chunk sizes: %s"
-            % (chunk_size, str(actual_chunk_lengths[:-1]))
+            "All chunks (except the last one) MUST be == `chunk_size`. chunk_size=%i\n\nactual chunk sizes: %s\n\nactual chunk names: %s"
+            % (chunk_size, str(actual_chunk_lengths[:-1]), str(actual_chunk_names))
         )
 
 

--- a/hub/core/chunk_engine/tests/common.py
+++ b/hub/core/chunk_engine/tests/common.py
@@ -55,8 +55,7 @@ def assert_chunk_sizes(
     incomplete_chunk_names = set()
     complete_chunk_count = 0
     total_chunks = 0
-    actual_chunk_lengths = []
-    actual_chunk_names = set()
+    actual_chunk_lengths_dict = {}
     for i, entry in enumerate(index_map):
         for j, chunk_name in enumerate(entry["chunk_names"]):
             chunk_key = get_chunk_key(key, chunk_name)
@@ -73,9 +72,10 @@ def assert_chunk_sizes(
                 j,
             )
 
-            if chunk_name not in actual_chunk_names:
-                actual_chunk_lengths.append(chunk_length)
-                actual_chunk_names.add(chunk_name)
+            if chunk_name in actual_chunk_lengths_dict:
+                assert chunk_length == actual_chunk_lengths_dict[chunk_name], "Chunk size changed from one read to another."
+            else:
+                actual_chunk_lengths_dict[chunk_name] = chunk_length
 
             if chunk_length < chunk_size:
                 incomplete_chunk_names.add(chunk_name)
@@ -95,11 +95,11 @@ def assert_chunk_sizes(
     )
 
     # assert that all chunks are of expected size (`chunk_size`)
-    actual_chunk_lengths = np.array(actual_chunk_lengths)
+    actual_chunk_lengths = np.array(list(actual_chunk_lengths_dict.values()))
     if len(actual_chunk_lengths) > 1:
         assert np.all(actual_chunk_lengths[:-1] == chunk_size), (
             "All chunks (except the last one) MUST be == `chunk_size`. chunk_size=%i\n\nactual chunk sizes: %s\n\nactual chunk names: %s"
-            % (chunk_size, str(actual_chunk_lengths[:-1]), str(actual_chunk_names))
+            % (chunk_size, str(actual_chunk_lengths[:-1]), str(actual_chunk_lengths_dict.keys()))
         )
 
 

--- a/hub/core/chunk_engine/tests/common.py
+++ b/hub/core/chunk_engine/tests/common.py
@@ -94,7 +94,7 @@ def assert_chunk_sizes(
         str(incomplete_chunk_names),
     )
 
-    # assert that all chunks are of expected size (`chunk_size`)
+    # assert that all chunks (except the last one) are of expected size (`chunk_size`)
     actual_chunk_lengths = np.array(list(actual_chunk_lengths_dict.values()))
     if len(actual_chunk_lengths) > 1:
         assert np.all(actual_chunk_lengths[:-1] == chunk_size), (

--- a/hub/core/chunk_engine/tests/common.py
+++ b/hub/core/chunk_engine/tests/common.py
@@ -55,6 +55,7 @@ def assert_chunk_sizes(
     incomplete_chunk_names = set()
     complete_chunk_count = 0
     total_chunks = 0
+    actual_chunk_lengths = []
     for i, entry in enumerate(index_map):
         for j, chunk_name in enumerate(entry["chunk_names"]):
             chunk_key = get_chunk_key(key, chunk_name)
@@ -70,6 +71,8 @@ def assert_chunk_sizes(
                 i,
                 j,
             )
+
+            actual_chunk_lengths.append(chunk_length)
 
             if chunk_length < chunk_size:
                 incomplete_chunk_names.add(chunk_name)
@@ -87,6 +90,14 @@ def assert_chunk_sizes(
         total_chunks,
         str(incomplete_chunk_names),
     )
+
+    # assert that all chunks are of expected size (`chunk_size`)
+    actual_chunk_lengths = np.array(actual_chunk_lengths)
+    if len(actual_chunk_lengths) > 1:
+        assert np.all(actual_chunk_lengths[:-1] == chunk_size), (
+            "All chunks (except the last one) MUST be == `chunk_size`. chunk_size=%i\n\nactual chunk sizes: %s"
+            % (chunk_size, str(actual_chunk_lengths[:-1]))
+        )
 
 
 def run_engine_test(

--- a/hub/tests/common.py
+++ b/hub/tests/common.py
@@ -2,7 +2,7 @@ import pytest
 import os
 from uuid import uuid1
 
-from hub.constants import KB, MB
+from hub.constants import B, KB, MB
 
 
 SESSION_ID = str(uuid1())
@@ -19,6 +19,8 @@ NUM_BATCHES = (1,)
 
 
 CHUNK_SIZES = (
+    1 * B,
+    8 * B,
     1 * KB,
     1 * MB,
     16 * MB,

--- a/hub/tests/common.py
+++ b/hub/tests/common.py
@@ -19,8 +19,6 @@ NUM_BATCHES = (1,)
 
 
 CHUNK_SIZES = (
-    1 * B,
-    8 * B,
     1 * KB,
     1 * MB,
     16 * MB,


### PR DESCRIPTION
this PR depends on #870 to be merged first.

this PR set out to fix the bug for chunk sizes not being exactly = `chunk_size`. however, it is deemed the problem actually doesn't exist! :) when looking at the s3 dashboard, sizes are shown as `15.3MB` however, because s3 console uses `ls -lah ${dir}` to get this sizing information, it is inaccurate. because if you use `wc -c ${filename}` it shows that the file size is actually exactly = `chunk_size`!

this PR does however still add explicit size assertion for chunk sizes (in case this problem does arise in the future). `assert_chunk_sizes` now doesn't just check incomplete chunk sizes, but it also checks every chunk (except last) and asserts that it is exactly equal to `chunk_size`.