### PR TITLE
Depickle and convert index_map to list

### DIFF
--- a/hub/core/chunk_engine/read.py
+++ b/hub/core/chunk_engine/read.py
@@ -1,6 +1,7 @@
 import os
 import pickle  # TODO: NEVER USE PICKLE
 from typing import Callable, List, Optional, Union
+import json
 
 import numpy as np
 from hub import constants
@@ -9,15 +10,15 @@ from hub.util.keys import get_index_map_key, get_tensor_meta_key
 
 
 def read_tensor_meta(key: str, storage: StorageProvider) -> dict:
-    return pickle.loads(storage[get_tensor_meta_key(key)])
+    return json.loads(storage[get_tensor_meta_key(key)])
 
 
 def read_index_map(key: str, storage: StorageProvider) -> List[dict]:
-    return pickle.loads(storage[get_index_map_key(key)])
+    return json.loads(storage[get_index_map_key(key)])
 
 
 def read_dataset_meta(storage: StorageProvider) -> dict:
-    return pickle.loads(storage[constants.META_FILENAME])
+    return json.loads(storage[constants.META_FILENAME])
 
 
 def tensor_exists(key: str, storage: StorageProvider) -> bool:

--- a/hub/core/chunk_engine/read.py
+++ b/hub/core/chunk_engine/read.py
@@ -1,5 +1,4 @@
 import os
-import pickle  # TODO: NEVER USE PICKLE
 from typing import Callable, List, Optional, Union
 import json
 
@@ -63,18 +62,18 @@ def sample_from_index_entry(
     """Get the unchunked sample from a single `index_map` entry."""
 
     b = bytearray()
-    for chunk_name in index_entry["chunk_names"]:
+    for chunk_name in index_entry[1]:
         chunk_key = os.path.join(key, "chunks", chunk_name)
         last_b_len = len(b)
         b.extend(storage[chunk_key])
 
-    start_byte = index_entry["start_byte"]
-    end_byte = last_b_len + index_entry["end_byte"]
+    start_byte = index_entry[3]
+    end_byte = last_b_len + index_entry[5]
 
     return array_from_buffer(
         memoryview(b),
         dtype,
-        index_entry["shape"],
+        index_entry[7],
         start_byte,
         end_byte,
     )

--- a/hub/core/chunk_engine/tests/common.py
+++ b/hub/core/chunk_engine/tests/common.py
@@ -58,7 +58,7 @@ def assert_chunk_sizes(
     total_chunks = 0
     actual_chunk_lengths_dict: Dict[str, int] = {}
     for i, entry in enumerate(index_map):
-        for j, chunk_name in enumerate(entry["chunk_names"]):
+        for j, chunk_name in enumerate(entry[1]):
             chunk_key = get_chunk_key(key, chunk_name)
             chunk_length = len(storage[chunk_key])
 

--- a/hub/core/chunk_engine/tests/common.py
+++ b/hub/core/chunk_engine/tests/common.py
@@ -142,8 +142,8 @@ def run_engine_test(
                 "chunk_size": chunk_size,
                 "length": a_in.shape[0],
                 "dtype": a_in.dtype.name,
-                "min_shape": tuple(a_in.shape[1:]),
-                "max_shape": tuple(a_in.shape[1:]),
+                "min_shape": list(a_in.shape[1:]),
+                "max_shape": list(a_in.shape[1:]),
             },
         )
 

--- a/hub/core/chunk_engine/write.py
+++ b/hub/core/chunk_engine/write.py
@@ -111,7 +111,7 @@ def write_bytes(
     key: str,
     chunk_size: int,
     storage: StorageProvider,
-    index_map: List,
+    index_map: list,
 ) -> dict:
     """Chunk and write bytes to storage and return the index_map entry. The provided bytes are treated as a single sample.
 
@@ -182,7 +182,7 @@ def write_bytes(
 
 
 def _get_last_chunk(
-    key: str, index_map: List, storage: StorageProvider
+    key: str, index_map: list, storage: StorageProvider
 ) -> Tuple[str, memoryview]:
     """Retrieves the name and memoryview of bytes for the last chunk that was written to. This is helpful for
     filling previous chunks before creating new ones.

--- a/hub/core/chunk_engine/write.py
+++ b/hub/core/chunk_engine/write.py
@@ -1,6 +1,7 @@
 import pickle  # TODO: NEVER USE PICKLE
 from typing import Any, Callable, List, Tuple
 from uuid import uuid1
+import json
 
 import numpy as np
 from hub.constants import DEFAULT_CHUNK_SIZE, META_FILENAME
@@ -14,17 +15,24 @@ from .flatten import row_wise_to_bytes
 from .read import read_index_map, read_tensor_meta, tensor_exists
 
 
+def _listify(shape: Tuple):
+    shapeArray = np.asarray(shape)
+    return shapeArray.tolist()
+
+
 def write_tensor_meta(key: str, storage: StorageProvider, meta: dict):
-    storage[get_tensor_meta_key(key)] = pickle.dumps(meta)
+    meta["min_shape"] = _listify(meta["min_shape"])
+    meta["max_shape"] = _listify(meta["max_shape"])
+    storage[get_tensor_meta_key(key)] = bytes(json.dumps(meta), "utf-8")
 
 
 def write_index_map(key: str, storage: StorageProvider, index_map: list):
     index_map_key = get_index_map_key(key)
-    storage[index_map_key] = pickle.dumps(index_map)
+    storage[index_map_key] = json.dumps(index_map)
 
 
 def write_dataset_meta(storage: StorageProvider, meta: dict):
-    storage[META_FILENAME] = pickle.dumps(meta)
+    storage[META_FILENAME] = json.dumps(meta)
 
 
 def add_samples_to_tensor(

--- a/hub/core/chunk_engine/write.py
+++ b/hub/core/chunk_engine/write.py
@@ -72,7 +72,7 @@ def add_samples_to_tensor(
         _check_array_and_tensor_are_compatible(tensor_meta, array, chunk_size)
 
     else:
-        index_map: List[dict] = []  # type: ignore
+        index_map: List = []  # type: ignore
         tensor_meta = {
             "chunk_size": chunk_size,
             "dtype": array.dtype.name,
@@ -100,7 +100,7 @@ def add_samples_to_tensor(
             item for sublist in dict_to_list(index_map_entry) for item in sublist
         ]
 
-        index_map.append(index_list)
+        index_map.append(np.asarray(index_list).tolist())
 
     write_tensor_meta(key, storage, tensor_meta)
     write_index_map(key, storage, index_map)
@@ -111,7 +111,7 @@ def write_bytes(
     key: str,
     chunk_size: int,
     storage: StorageProvider,
-    index_map: List[dict],
+    index_map: List,
 ) -> dict:
     """Chunk and write bytes to storage and return the index_map entry. The provided bytes are treated as a single sample.
 
@@ -182,7 +182,7 @@ def write_bytes(
 
 
 def _get_last_chunk(
-    key: str, index_map: List[dict], storage: StorageProvider
+    key: str, index_map: List, storage: StorageProvider
 ) -> Tuple[str, memoryview]:
     """Retrieves the name and memoryview of bytes for the last chunk that was written to. This is helpful for
     filling previous chunks before creating new ones.

--- a/hub/core/storage/tests/test_benchmark_storage_provider.py
+++ b/hub/core/storage/tests/test_benchmark_storage_provider.py
@@ -18,9 +18,6 @@ for chunk_size in BENCHMARK_CHUNK_SIZES:
         NUM_CHUNKS.append(data_size // chunk_size)
 
 
-mark_cache_group = pytest.mark.benchmark(group="storage_with_caches")
-mark_no_cache_group = pytest.mark.benchmark(group="storage_without_caches")
-
 parametrize_benchmark_num_chunks = pytest.mark.parametrize("num_chunks", NUM_CHUNKS)
 
 
@@ -36,7 +33,7 @@ def read_from_files(storage, num_chunks):
         storage[f"{KEY}_{i}"]
 
 
-@mark_no_cache_group
+@pytest.mark.benchmark(group="storage_without_caches_write")
 @parametrize_all_storages
 @parametrize_benchmark_chunk_sizes
 @parametrize_benchmark_num_chunks
@@ -44,7 +41,7 @@ def test_storage_write_speeds(benchmark, storage, chunk_size, num_chunks):
     benchmark(write_to_files, storage, chunk_size, num_chunks)
 
 
-@mark_cache_group
+@pytest.mark.benchmark(group="storage_with_caches_write")
 @parametrize_all_caches
 @parametrize_benchmark_chunk_sizes
 @parametrize_benchmark_num_chunks
@@ -52,7 +49,7 @@ def test_cache_write_speeds(benchmark, storage, chunk_size, num_chunks):
     benchmark(write_to_files, storage, chunk_size, num_chunks)
 
 
-@mark_no_cache_group
+@pytest.mark.benchmark(group="storage_without_caches_read")
 @parametrize_all_storages
 @parametrize_benchmark_chunk_sizes
 @parametrize_benchmark_num_chunks
@@ -61,7 +58,7 @@ def test_storage_read_speeds(benchmark, storage, chunk_size, num_chunks):
     benchmark(read_from_files, storage, num_chunks)
 
 
-@mark_cache_group
+@pytest.mark.benchmark(group="storage_with_caches_read")
 @parametrize_all_caches
 @parametrize_benchmark_chunk_sizes
 @parametrize_benchmark_num_chunks
@@ -70,7 +67,7 @@ def test_cache_read_speeds(benchmark, storage, chunk_size, num_chunks):
     benchmark(read_from_files, storage, num_chunks)
 
 
-@mark_cache_group
+@pytest.mark.benchmark(group="storage_with_caches_read_write")
 @parametrize_all_caches
 @parametrize_benchmark_chunk_sizes
 @parametrize_benchmark_num_chunks


### PR DESCRIPTION
1.  Remove pickle instances (pickle -> json)
2. Convert index_map to list of lists
3. Edit tests to work with above changes
4. Split storage benchmark tests on cache read/write