### PR TITLE
Feature - additional CSV parsing 

### DIFF
--- a/hub/__init__.py
+++ b/hub/__init__.py
@@ -21,7 +21,7 @@ from hub.exceptions import DaskModuleNotInstalledException, HubDatasetNotFoundEx
 from hub.report import hub_reporter, hub_tags
 from hub.version import __version__
 
-# hub_reporter.setup_excepthook(tags=hub_tags)
+hub_reporter.setup_excepthook(tags=hub_tags)
 hub_reporter.system_report(tags=hub_tags)
 
 

--- a/hub/__init__.py
+++ b/hub/__init__.py
@@ -21,7 +21,7 @@ from hub.exceptions import DaskModuleNotInstalledException, HubDatasetNotFoundEx
 from hub.report import hub_reporter, hub_tags
 from hub.version import __version__
 
-hub_reporter.setup_excepthook(tags=hub_tags)
+# hub_reporter.setup_excepthook(tags=hub_tags)
 hub_reporter.system_report(tags=hub_tags)
 
 

--- a/hub/api/dataset.py
+++ b/hub/api/dataset.py
@@ -1098,7 +1098,7 @@ class Dataset:
         return ds
 
     @staticmethod
-    def from_path(path, scheduler="single", workers=1, sep=","):
+    def from_path(path, scheduler="single", workers=1, **kwargs):
         # infer schema & get data (label -> input mapping with file refs)
-        ds = auto.infer_dataset(path, scheduler=scheduler, workers=workers, sep=sep)
+        ds = auto.infer_dataset(path, scheduler, workers, **kwargs)
         return ds

--- a/hub/api/dataset.py
+++ b/hub/api/dataset.py
@@ -1098,7 +1098,7 @@ class Dataset:
         return ds
 
     @staticmethod
-    def from_path(path, scheduler="single", workers=1):
+    def from_path(path, scheduler="single", workers=1, sep=","):
         # infer schema & get data (label -> input mapping with file refs)
-        ds = auto.infer_dataset(path, scheduler=scheduler, workers=workers)
+        ds = auto.infer_dataset(path, scheduler=scheduler, workers=workers, sep=sep)
         return ds

--- a/hub/auto/computer_vision/classification.py
+++ b/hub/auto/computer_vision/classification.py
@@ -12,7 +12,7 @@ USE_TQDM = True
 
 
 @state.directory_parser(priority=0)
-def image_classification(path, scheduler, workers, sep):
+def image_classification(path, scheduler, workers, **kwargs):
     children = util.get_children(path, only_dirs=True)
 
     # check if there is >= 2 children (means there are at least 2 folders)
@@ -86,7 +86,7 @@ def image_classification(path, scheduler, workers, sep):
 
 
 @state.directory_parser(priority=2)
-def multiple_image_parse(path, scheduler=None, workers=None):
+def multiple_image_parse(path, scheduler=None, workers=None, **kwargs):
     """Helper function to upload classification dataset of the following directory structure.
 
     ```python3
@@ -101,8 +101,6 @@ def multiple_image_parse(path, scheduler=None, workers=None):
     store_ds = []
     for files in list_folder:
         tag = str(files)
-        ds = image_classification(
-            os.path.join(path, files), scheduler, workers, sep=","
-        )
+        ds = image_classification(os.path.join(path, files), scheduler, workers)
         directory_dict[tag] = ds
     return directory_dict

--- a/hub/auto/computer_vision/classification.py
+++ b/hub/auto/computer_vision/classification.py
@@ -12,7 +12,7 @@ USE_TQDM = True
 
 
 @state.directory_parser(priority=0)
-def image_classification(path, scheduler, workers):
+def image_classification(path, scheduler, workers, sep):
     children = util.get_children(path, only_dirs=True)
 
     # check if there is >= 2 children (means there are at least 2 folders)
@@ -101,6 +101,8 @@ def multiple_image_parse(path, scheduler=None, workers=None):
     store_ds = []
     for files in list_folder:
         tag = str(files)
-        ds = image_classification(os.path.join(path, files), scheduler, workers)
+        ds = image_classification(
+            os.path.join(path, files), scheduler, workers, sep=","
+        )
         directory_dict[tag] = ds
     return directory_dict

--- a/hub/auto/computer_vision/classification.py
+++ b/hub/auto/computer_vision/classification.py
@@ -13,6 +13,9 @@ USE_TQDM = True
 
 @state.directory_parser(priority=0)
 def image_classification(path, scheduler, workers, **kwargs):
+    if not os.path.isdir(path):
+        raise Exception("The input path must be a directory.")
+
     children = util.get_children(path, only_dirs=True)
 
     # check if there is >= 2 children (means there are at least 2 folders)
@@ -98,6 +101,9 @@ def multiple_image_parse(path, scheduler=None, workers=None, **kwargs):
     ```
 
     """
+    if not os.path.isdir(path):
+        raise Exception("The input path must be a directory.")
+
     list_folder = os.listdir(path)
     directory_dict = dict()
     store_ds = []

--- a/hub/auto/computer_vision/classification.py
+++ b/hub/auto/computer_vision/classification.py
@@ -17,13 +17,15 @@ def image_classification(path, scheduler, workers, **kwargs):
 
     # check if there is >= 2 children (means there are at least 2 folders)
     if len(children) < 2:
-        print("test1")
+        print("Image Classification Parser: Less than 2 folders present.")
         return None
 
     # check if children's contents has image files
     for child in children:
         if not util.files_are_of_extension(child, util.IMAGE_EXTS):
-            print("test2")
+            print(
+                "Image Classification Parser: The files are not of any accepted extension type."
+            )
             return None
 
     # parse dataset
@@ -34,7 +36,7 @@ def image_classification(path, scheduler, workers, **kwargs):
     image_shape = None  # if shape is all the same, use that instead of max_shape
     for child in tqdm(
         children,
-        desc="parsing image classification dataset",
+        desc="Parsing Image Classification Dataset",
         total=len(children),
         disable=not USE_TQDM,
     ):

--- a/hub/auto/computer_vision/classification.py
+++ b/hub/auto/computer_vision/classification.py
@@ -13,8 +13,9 @@ USE_TQDM = True
 
 @state.directory_parser(priority=0)
 def image_classification(path, scheduler, workers, **kwargs):
+    # Returning None if the input path is not a directory
     if not os.path.isdir(path):
-        raise Exception("The input path must be a directory.")
+        return None
 
     children = util.get_children(path, only_dirs=True)
 
@@ -101,8 +102,9 @@ def multiple_image_parse(path, scheduler=None, workers=None, **kwargs):
     ```
 
     """
+    # Returning None if the input path is not a directory
     if not os.path.isdir(path):
-        raise Exception("The input path must be a directory.")
+        return None
 
     list_folder = os.listdir(path)
     directory_dict = dict()

--- a/hub/auto/infer.py
+++ b/hub/auto/infer.py
@@ -40,7 +40,7 @@ def _find_root(path):
     return path
 
 
-def infer_dataset(path, scheduler, workers, sep):
+def infer_dataset(path, scheduler, workers, **kwargs):
     # TODO: handle s3 path
 
     if not os.path.isdir(path):
@@ -62,7 +62,7 @@ def infer_dataset(path, scheduler, workers, sep):
     # go through all functions created using the `directory_parser` decorator in
     # `hub.schema.auto.directory_parsers`
     for parser in directory_parsers:
-        ds = parser(root, scheduler, workers, sep)
+        ds = parser(root, scheduler, workers, **kwargs)
         if ds is not None:
             break
 

--- a/hub/auto/infer.py
+++ b/hub/auto/infer.py
@@ -3,6 +3,7 @@ from glob import glob
 
 import hub
 from hub.auto import util
+import shutil
 
 state = util.DirectoryParserState()
 
@@ -42,15 +43,21 @@ def _find_root(path):
 
 def infer_dataset(path, scheduler, workers, **kwargs):
     # TODO: handle s3 path
-
+    # overwrite, a keyword argument, can be specified if
+    # the existing Hub dataset auto inferred has to be deleted on re-run of the command
+    overwrite = kwargs["overwrite"] if "overwrite" in kwargs else False
     if not os.path.isdir(path):
-        raise Exception("input path must be either a directory")
+        raise Exception("The input path must be a directory.")
 
     hub_path = os.path.join("./", path, "hub")
 
     if os.path.isdir(hub_path):
-        print('inferred dataset found in "%s", using that' % hub_path)
-        return hub.Dataset(hub_path, mode="r")
+        if overwrite is True:
+            print(f"Inferred dataset found at {hub_path}, but deleting.")
+            shutil.rmtree(hub_path)
+        if overwrite is False:
+            print(f"Inferred dataset found at {hub_path}, using that")
+            return hub.Dataset(hub_path, mode="r")
 
     root = _find_root(path)
     ds = None

--- a/hub/auto/infer.py
+++ b/hub/auto/infer.py
@@ -47,7 +47,10 @@ def infer_dataset(path, scheduler, workers, **kwargs):
     # the existing Hub dataset auto inferred has to be deleted on re-run of the command
     overwrite = kwargs["overwrite"] if "overwrite" in kwargs else False
 
-    hub_path = os.path.join("./", path, "hub")
+    if not os.path.isdir(path):
+        hub_path = os.path.join("./", os.path.dirname(path), "hub")
+    else:
+        hub_path = os.path.join("./", path, "hub")
 
     if os.path.isdir(hub_path):
         if overwrite is True:

--- a/hub/auto/infer.py
+++ b/hub/auto/infer.py
@@ -40,7 +40,7 @@ def _find_root(path):
     return path
 
 
-def infer_dataset(path, scheduler="single", workers=1):
+def infer_dataset(path, scheduler, workers, sep):
     # TODO: handle s3 path
 
     if not os.path.isdir(path):
@@ -62,7 +62,7 @@ def infer_dataset(path, scheduler="single", workers=1):
     # go through all functions created using the `directory_parser` decorator in
     # `hub.schema.auto.directory_parsers`
     for parser in directory_parsers:
-        ds = parser(root, scheduler, workers)
+        ds = parser(root, scheduler, workers, sep)
         if ds is not None:
             break
 

--- a/hub/auto/infer.py
+++ b/hub/auto/infer.py
@@ -46,8 +46,6 @@ def infer_dataset(path, scheduler, workers, **kwargs):
     # overwrite, a keyword argument, can be specified if
     # the existing Hub dataset auto inferred has to be deleted on re-run of the command
     overwrite = kwargs["overwrite"] if "overwrite" in kwargs else False
-    if not os.path.isdir(path):
-        raise Exception("The input path must be a directory.")
 
     hub_path = os.path.join("./", path, "hub")
 

--- a/hub/auto/tabular/csv.py
+++ b/hub/auto/tabular/csv.py
@@ -9,11 +9,11 @@ from tqdm import tqdm
 
 
 @state.directory_parser(priority=1)
-def data_from_csv(path, scheduler, workers):
+def data_from_csv(path, scheduler, workers, sep):
     try:
         import pandas as pd
     except ModuleNotFoundError:
-        raise ModuleNotInstalledException("pandas")
+        raise ModuleNotInstalledException("Please install Pandas for CSV parsing.")
 
     # check if path's contents are all csv files
     if not util.files_are_of_extension(path, util.CSV_EXTS):
@@ -23,7 +23,12 @@ def data_from_csv(path, scheduler, workers):
     files = util.get_children(path)
 
     for i in files:
-        df_csv = pd.read_csv(i)
+        try:
+            df_csv = pd.read_csv(i, sep)
+        except pd.errors.ParserError:
+            raise pd.errors.ParserError(
+                f"Another seperator needs to be used to parse this CSV. The current seperator is {sep}"
+            )
         df_csv["Filename"] = os.path.basename(i)
         df = pd.concat([df, df_csv])
 

--- a/hub/auto/tabular/csv.py
+++ b/hub/auto/tabular/csv.py
@@ -9,7 +9,8 @@ from tqdm import tqdm
 
 
 @state.directory_parser(priority=1)
-def data_from_csv(path, scheduler, workers, sep):
+def data_from_csv(path, scheduler, workers, **kwargs):
+    sep = kwargs["sep"] if "sep" in kwargs else ","
     try:
         import pandas as pd
     except ModuleNotFoundError:

--- a/hub/auto/tabular/csv.py
+++ b/hub/auto/tabular/csv.py
@@ -17,10 +17,6 @@ def data_from_csv(path, scheduler, workers, **kwargs):
     except ModuleNotFoundError:
         raise ModuleNotInstalledException("Please install Pandas for CSV parsing.")
 
-    # check if path's contents are all csv files
-    if not util.files_are_of_extension(path, util.CSV_EXTS):
-        return None
-
     # check if the given path is a directory.
     # If path is a file, direct reading of CSV is attempted.
     if not os.path.isdir(path):
@@ -33,6 +29,9 @@ def data_from_csv(path, scheduler, workers, **kwargs):
 
     else:
         files = util.get_children(path)
+        # check if path's contents are all csv files
+        if not util.files_are_of_extension(path, util.CSV_EXTS):
+            return None
         df = pd.DataFrame()
         for i in files:
             try:

--- a/hub/auto/tests/test_image_classification.py
+++ b/hub/auto/tests/test_image_classification.py
@@ -70,7 +70,9 @@ def test_class_sample_different_shapes():
 
 
 def test_auto_multiple_dataset_parser():
-    path_to_data = "dummy_data/image_classification/class_sample_multiple_folder"
+    path_to_data = (
+        "hub/auto/tests/dummy_data/image_classification/class_sample_multiple_folder"
+    )
     keys = tuple(
         multiple_image_parse(path_to_data, scheduler="single", workers=1).keys()
     )

--- a/hub/auto/tests/test_image_classification.py
+++ b/hub/auto/tests/test_image_classification.py
@@ -70,10 +70,7 @@ def test_class_sample_different_shapes():
 
 
 def test_auto_multiple_dataset_parser():
-    path_to_data = (
-        "hub/auto/tests/dummy_data/image_classification/class_sample_multiple_folder"
-    )
-
+    path_to_data = "dummy_data/image_classification/class_sample_multiple_folder"
     keys = tuple(
         multiple_image_parse(path_to_data, scheduler="single", workers=1).keys()
     )

--- a/hub/compute/transform.py
+++ b/hub/compute/transform.py
@@ -138,7 +138,7 @@ class Transform:
 
     @classmethod
     def _flatten_dict(self, d: Dict, parent_key="", schema=None):
-        """| Helper function to flatten dictionary of a recursive tensor
+        """| Helper function to flatten dictionary of a recursive tensor.
 
         Parameters
         ----------
@@ -160,7 +160,7 @@ class Transform:
     @classmethod
     def dtype_from_path(cls, path, schema):
         """
-        Helper function to get the dtype from the path
+        Helper function to get the dtype from the path.
         """
         path = path.split("/")
         cur_type = schema
@@ -172,7 +172,7 @@ class Transform:
     @classmethod
     def _unwrap(cls, results):
         """
-        If there is any list then unwrap it into its elements
+        If there is any list then unwrap it into its elements.
         """
         items = []
         for r in results:
@@ -183,7 +183,7 @@ class Transform:
         return items
 
     def _split_list_to_dicts(self, xs):
-        """| Helper function that transform list of dicts into dicts of lists
+        """| Helper function that transform list of dicts into dicts of lists.
 
         Parameters
         ----------
@@ -208,7 +208,7 @@ class Transform:
 
     def _pbar(self, show: bool = True):
         """
-        Returns a progress bar, if empty then it function does nothing
+        Returns a progress bar, if empty then this function does nothing.
         """
 
         def _empty_pbar(xs, **kwargs):
@@ -220,7 +220,7 @@ class Transform:
     def create_dataset(
         self, url: str, length: int = None, token: dict = None, public: bool = True
     ):
-        """Helper function to create a dataset"""
+        """Helper function to create a dataset."""
         shape = (length,)
         ds = Dataset(
             url,
@@ -235,7 +235,8 @@ class Transform:
         return ds
 
     def upload(self, results, ds: Dataset, token: dict, progressbar: bool = True):
-        """Batchified upload of results.
+        """
+        Batchified upload of results.
         For each tensor batchify based on its chunk and upload.
         If tensor is dynamic then still upload element by element.
         For dynamic tensors, it disable dynamicness and then enables it back.
@@ -301,7 +302,7 @@ class Transform:
         return ds
 
     def call_func(self, fn_index, item, as_list=False):
-        """Calls all the functions one after the other
+        """Calls all the functions one after the other.
 
         Parameters
         ----------
@@ -329,7 +330,7 @@ class Transform:
 
     def store_shard(self, ds_in: Iterable, ds_out: Dataset, offset: int, token=None):
         """
-        Takes a shard of iteratable ds_in, compute and stores in DatasetView
+        Takes a shard of iteratable ds_in, compute and stores in DatasetView.
         """
 
         def _func_argd(item):


### PR DESCRIPTION
This PR introduces a few new arguments for `hub.auto`: `sep` (for tabular data parsing), and `overwrite` (for all types of datasets).
`sep`: a keyword argument that specifies the delimiter to be used for CSV parsing. Default value: `,`
`overwrite`: a keyword argument that specifies if an existing Hub dataset found at the given `path` is to be overwritten when running `Dataset.from_path`. Default value: `False` 
Both have been included as `kwargs` to avoid explicit coding of these arguments into the parsers.
I've also added functionality to directly read `.csv` files as opposed to before where the `.csv` file(s) needed to be present in a directory to be parsed.
Also, made a few (very) small corrections to various docstrings in `transform.py` and `classification.py`