### PR TITLE
Fix/2.0/empty samples

### DIFF
--- a/hub/api/tests/test_api.py
+++ b/hub/api/tests/test_api.py
@@ -167,6 +167,24 @@ def test_empty_samples(ds: Dataset):
         np.testing.assert_array_equal(actual, expected)
 
 
+parametrize_all_dataset_storages
+
+
+def test_scalar_samples(ds: Dataset):
+    tensor = ds.create_tensor("scalars", dtype="int64")
+
+    tensor.append(5)
+    tensor.append(10)
+    tensor.append(-99)
+    tensor.extend([10, 1, 4])
+    tensor.extend([1])
+
+    assert len(tensor) == 7
+
+    expected = np.array([5, 10, -99, 10, 1, 4, 1])
+    np.testing.assert_array_equal(tensor.numpy(), expected)
+
+
 @parametrize_all_dataset_storages
 def test_iterate_dataset(ds):
     labels = [1, 9, 7, 4]

--- a/hub/api/tests/test_api.py
+++ b/hub/api/tests/test_api.py
@@ -167,24 +167,6 @@ def test_empty_samples(ds: Dataset):
         np.testing.assert_array_equal(actual, expected)
 
 
-parametrize_all_dataset_storages
-
-
-def test_scalar_samples(ds: Dataset):
-    tensor = ds.create_tensor("scalars", dtype="int64")
-
-    tensor.append(5)
-    tensor.append(10)
-    tensor.append(-99)
-    tensor.extend([10, 1, 4])
-    tensor.extend([1])
-
-    assert len(tensor) == 7
-
-    expected = np.array([5, 10, -99, 10, 1, 4, 1])
-    np.testing.assert_array_equal(tensor.numpy(), expected)
-
-
 @parametrize_all_dataset_storages
 def test_iterate_dataset(ds):
     labels = [1, 9, 7, 4]

--- a/hub/core/chunk_engine/read.py
+++ b/hub/core/chunk_engine/read.py
@@ -12,8 +12,15 @@ def sample_from_index_entry(
 ) -> np.ndarray:
     """Get the un-chunked sample from a single `index_meta` entry."""
 
+    chunk_names = index_entry["chunk_names"]
+    shape = index_entry["shape"]
+
+    # sample has no data
+    if len(chunk_names) <= 0:
+        return np.zeros(shape, dtype=dtype)
+
     b = bytearray()
-    for chunk_name in index_entry["chunk_names"]:
+    for chunk_name in chunk_names:
         chunk_key = os.path.join(key, "chunks", chunk_name)
         last_b_len = len(b)
         b.extend(storage[chunk_key])
@@ -24,7 +31,7 @@ def sample_from_index_entry(
     return array_from_buffer(
         memoryview(b),
         dtype,
-        index_entry["shape"],
+        shape,
         start_byte,
         end_byte,
     )

--- a/hub/core/chunk_engine/write.py
+++ b/hub/core/chunk_engine/write.py
@@ -21,7 +21,7 @@ def write_array(
     """Chunk and write an array to storage, also updates `index_meta`/`tensor_meta`. The provided array is treated as a batched of samples.
 
     Args:
-        array (np.ndarray): Batched array to be chunked/written. 
+        array (np.ndarray): Batched array to be chunked/written.
         key (str): Key for where the index_meta and tensor_meta are located in `storage` relative to it's root.
             A subdirectory is created under this `key` (defined in `constants.py`), which is where the chunks will be
             stored.
@@ -37,9 +37,10 @@ def write_array(
 
     for i in range(num_samples):
         sample = array[i]
+        extra_sample_meta = {"shape": sample.shape}
+
         if 0 in sample.shape:
-            # if sample has a 0 in the shape, no data will be written
-            index_entry = {"chunk_names": []}  # type: ignore
+            write_empty_sample(index_meta, extra_sample_meta=extra_sample_meta)
 
         else:
             # TODO: we may want to call `tobytes` on `array` and call memoryview on that. this may depend on the access patterns we
@@ -51,12 +52,18 @@ def write_array(
                 storage,
                 tensor_meta,
                 index_meta,
-                extra_sample_meta={"shape": sample.shape},  # TODO: use kwargs
+                extra_sample_meta=extra_sample_meta,  # TODO: use kwargs
             )
 
         tensor_meta.update_with_sample(sample, key)
 
     tensor_meta.length += num_samples
+
+
+def write_empty_sample(index_meta, extra_sample_meta: dict = {}):
+    """Simply adds an entry to `index_map` that symbolizes an empty array."""
+
+    index_meta.add_entry(chunk_names=[], start_byte=0, end_byte=0, **extra_sample_meta)
 
 
 def write_bytes(

--- a/hub/core/tensor.py
+++ b/hub/core/tensor.py
@@ -142,7 +142,6 @@ def read_samples_from_tensor(
 
     Raises:
         DynamicTensorNumpyError: If reading a dynamically-shaped array slice without `aslist=True`.
-        NotImplementedError: Empty samples (shape contains 0) not implemented.
 
     Returns:
         np.ndarray: Array containing the sample(s) in the `array_slice` slice.
@@ -164,10 +163,6 @@ def read_samples_from_tensor(
         last_shape = index_entries[i - 1]["shape"]
         if not aslist and shape != last_shape:
             raise DynamicTensorNumpyError(key, index)
-
-        if 0 in shape:
-            # TODO: implement support for 0s in shape and update docstring
-            raise NotImplementedError("0s in shapes are not supported yet.")
 
         array = sample_from_index_entry(key, storage, index_entry, tensor_meta.dtype)
         samples.append(array)


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### What is it?

Very short PR. Simply allows:

```python
ds = Dataset(...)
tensor = ds.create_tensor("tensor")

tensor.append(np.ones((100, 100)))
tensor.append(np.ones((100, 0)))  # empty sample
```

Empty samples have their initial shape/dtype saved. it is noted, but no data is actually written. Only the `IndexMeta` is modified.

### Checklist:

- [ ]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [ ]  I have performed a self-review of my own code and resolved any problems
- [ ]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [ ]  New and existing unit tests pass locally with my changes


### Changes

<!-- Describe your changes! Describe the scope of this PR's responsibilities. -->
