### PR TITLE
add scalar samples test (it already passes :))

### DIFF
--- a/hub/api/tests/test_api.py
+++ b/hub/api/tests/test_api.py
@@ -166,6 +166,20 @@ def test_empty_samples(ds: Dataset):
         actual = actual_sample.with_empty.numpy()
         np.testing.assert_array_equal(actual, expected)
 
+@parametrize_all_dataset_storages
+def test_scalar_samples(ds: Dataset):
+    tensor = ds.create_tensor("scalars", dtype="int64")
+
+    tensor.append(5)
+    tensor.append(10)
+    tensor.append(-99)
+    tensor.extend([10, 1, 4])
+    tensor.extend([1])
+
+    assert len(tensor) == 7
+
+    expected = np.array([5, 10, -99, 10, 1, 4, 1])
+    np.testing.assert_array_equal(tensor.numpy(), expected)
 
 @parametrize_all_dataset_storages
 def test_iterate_dataset(ds):

--- a/hub/api/tests/test_api.py
+++ b/hub/api/tests/test_api.py
@@ -166,6 +166,7 @@ def test_empty_samples(ds: Dataset):
         actual = actual_sample.with_empty.numpy()
         np.testing.assert_array_equal(actual, expected)
 
+
 @parametrize_all_dataset_storages
 def test_scalar_samples(ds: Dataset):
     tensor = ds.create_tensor("scalars", dtype="int64")
@@ -180,6 +181,7 @@ def test_scalar_samples(ds: Dataset):
 
     expected = np.array([5, 10, -99, 10, 1, 4, 1])
     np.testing.assert_array_equal(tensor.numpy(), expected)
+
 
 @parametrize_all_dataset_storages
 def test_iterate_dataset(ds):


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### What is it?

This PR literally only adds a test for scalar samples. Thanks to #949's refactor :)

This test makes sure the following works:
```python
tensor = ds.create_tensor(...)

tensor.append(5)
tensor.extend([5, 10])
tensor.extend([])  # does literally nothing, and makes sure that len(tensor) doesn't change
```

### Checklist:

- [ ]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [ ]  I have performed a self-review of my own code and resolved any problems
- [ ]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [ ]  New and existing unit tests pass locally with my changes


### Changes

<!-- Describe your changes! Describe the scope of this PR's responsibilities. -->
