### PR TITLE
[2.0] Add scalar outputs for numpy(aslist=True)

### DIFF
--- a/hub/api/tests/test_api.py
+++ b/hub/api/tests/test_api.py
@@ -183,6 +183,25 @@ def test_scalar_samples(ds: Dataset):
     expected = np.array([5, 10, -99, 10, 1, 4, 1])
     np.testing.assert_array_equal(tensor.numpy(), expected)
 
+    assert tensor.numpy(aslist=True) == expected.tolist()
+
+
+@parametrize_all_dataset_storages
+def test_sequence_samples(ds: Dataset):
+    tensor = ds.create_tensor("arrays")
+
+    tensor.append([1, 2, 3])
+    tensor.extend([[4, 5, 6]])
+
+    assert len(tensor) == 2
+
+    expected = np.array([[1, 2, 3], [4, 5, 6]])
+    np.testing.assert_array_equal(tensor.numpy(), expected)
+
+    assert type(tensor.numpy(aslist=True)) == list
+    np.testing.assert_array_equal(tensor.numpy(aslist=True)[0], np.array([1, 2, 3]))
+    np.testing.assert_array_equal(tensor.numpy(aslist=True)[1], np.array([4, 5, 6]))
+
 
 @parametrize_all_dataset_storages
 def test_iterate_dataset(ds):

--- a/hub/core/index/index.py
+++ b/hub/core/index/index.py
@@ -261,17 +261,22 @@ class Index:
         else:
             raise TypeError(f"Value {item} is of unrecognized type {type(item)}.")
 
-    def apply(self, array: np.ndarray):
-        """Applies an Index to a batched ndarray with the same number of samples
+    def apply(self, samples: List[np.ndarray]):
+        """Applies an Index to a list of ndarray samples with the same number of entries
         as the first entry in the Index.
         """
         index_values = tuple(item.value for item in self.values[1:])
-        if not self.values[0].subscriptable():
-            array = array[0]  # remove unit batch axis
-        else:
-            index_values = (slice(None),) + index_values
+        samples = list(arr[index_values] for arr in samples)
+        return samples
 
-        return array[index_values]
+    def apply_squeeze(self, samples: List[np.ndarray]):
+        """Applies the primary axis of an Index to a list of ndarray samples.
+        Will either return the list as given, or return the first sample.
+        """
+        if self.values[0].subscriptable():
+            return samples
+        else:
+            return samples[0]
 
     def is_trivial(self):
         """Checks if an index is equivalent to the trivial slice `[:]`, aka slice(None)."""

--- a/hub/core/tensor.py
+++ b/hub/core/tensor.py
@@ -167,10 +167,14 @@ def read_samples_from_tensor(
         array = sample_from_index_entry(key, storage, index_entry, tensor_meta.dtype)
         samples.append(array)
 
-    if aslist:
-        if index.values[0].subscriptable():
-            return samples
-        else:
-            return samples[0]
+    samples = index.apply(samples)
 
-    return index.apply(np.array(samples))
+    if aslist and all(map(np.isscalar, samples)):
+        samples = list(arr.item() for arr in samples)
+
+    samples = index.apply_squeeze(samples)
+
+    if aslist:
+        return samples
+    else:
+        return np.array(samples)


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [x]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [x]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [x]  I have performed a self-review of my own code and resolved any problems
- [x]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [x]  New and existing unit tests pass locally with my changes


### Changes

Enables scalar outputs for `.numpy(aslist=True)`:
```
>>> tensor.numpy(aslist=True)
[1, 2, 3]
```
instead of:
```
>>> tensor.numpy(aslist=True)
[array(1), array(2), array(3)]
```