### PR TITLE
[2.0] Change Dataset.__len__ and Tensor.__len__ to account for Index

### DIFF
--- a/hub/api/dataset.py
+++ b/hub/api/dataset.py
@@ -102,10 +102,10 @@ class Dataset:
         self.storage.autoflush = True
         self.flush()
 
-    # TODO len should consider slice
     def __len__(self):
         """Return the smallest length of tensors"""
-        return min(map(len, self.tensors.values()), default=0)
+        tensor_lengths = [len(tensor[self.index]) for tensor in self.tensors.values()]
+        return min(tensor_lengths, default=0)
 
     def __getitem__(
         self,
@@ -277,7 +277,7 @@ class Dataset:
     def __str__(self):
         path_str = ""
         if self.path:
-            path_str = f"path={self.path}, "
+            path_str = f"path='{self.path}', "
 
         mode_str = ""
         if self.read_only:

--- a/hub/api/tensor.py
+++ b/hub/api/tensor.py
@@ -141,8 +141,9 @@ class Tensor:
         return self.shape_interval.is_dynamic
 
     def __len__(self):
-        """Returns the length of the primary axis of a tensor."""
-        return self.meta.length
+        """Returns the length of the primary axis of a tensor.
+        Accounts for indexing into the tensor object."""
+        return self.index.length(self.meta.length)
 
     def __getitem__(
         self,

--- a/hub/api/tensor.py
+++ b/hub/api/tensor.py
@@ -142,7 +142,20 @@ class Tensor:
 
     def __len__(self):
         """Returns the length of the primary axis of a tensor.
-        Accounts for indexing into the tensor object."""
+        Accounts for indexing into the tensor object.
+
+        Examples:
+            >>> len(tensor)
+            0
+            >>> tensor.extend(np.zeros((100, 10, 10)))
+            >>> len(tensor)
+            100
+            >>> len(tensor[5:10])
+            5
+
+        Returns:
+            int: The current length of this tensor.
+        """
         return self.index.length(self.meta.length)
 
     def __getitem__(

--- a/hub/api/tests/test_api.py
+++ b/hub/api/tests/test_api.py
@@ -254,6 +254,17 @@ def test_length_slices(memory_ds):
     assert len(ds[1:10:2]) == 5
     assert len(ds[[0, 1, 5, 9]]) == 4
 
+    assert len(ds.data) == 11
+    assert len(ds.data[0]) == 1
+    assert len(ds.data[0:1]) == 1
+    assert len(ds.data[0:0]) == 0
+    assert len(ds.data[1:10]) == 9
+    assert len(ds.data[1:7:2]) == 3
+    assert len(ds.data[1:8:2]) == 4
+    assert len(ds.data[1:9:2]) == 4
+    assert len(ds.data[1:10:2]) == 5
+    assert len(ds.data[[0, 1, 5, 9]]) == 4
+
 
 def test_shape_property(memory_ds):
     fixed = memory_ds.create_tensor("fixed_tensor")

--- a/hub/api/tests/test_api.py
+++ b/hub/api/tests/test_api.py
@@ -102,7 +102,7 @@ def test_stringify(memory_ds):
 def test_stringify_with_path(local_ds):
     ds = local_ds
     assert local_ds.path
-    assert str(ds) == f"Dataset(path={local_ds.path}, tensors=[])"
+    assert str(ds) == f"Dataset(path='{local_ds.path}', tensors=[])"
 
 
 @parametrize_all_dataset_storages
@@ -264,6 +264,10 @@ def test_length_slices(memory_ds):
     assert len(ds.data[1:9:2]) == 4
     assert len(ds.data[1:10:2]) == 5
     assert len(ds.data[[0, 1, 5, 9]]) == 4
+
+    assert ds.data.shape == (11,)
+    assert ds[0:5].data.shape == (5,)
+    assert ds.data[1:6].shape == (5,)
 
 
 def test_shape_property(memory_ds):

--- a/hub/api/tests/test_api.py
+++ b/hub/api/tests/test_api.py
@@ -88,11 +88,12 @@ def test_stringify(memory_ds):
     ds.create_tensor("image")
     ds.image.extend(np.ones((4, 4)))
     assert (
-        str(ds) == "Dataset(path=hub_pytest/test_api/test_stringify, tensors=['image'])"
+        str(ds)
+        == "Dataset(path='hub_pytest/test_api/test_stringify', tensors=['image'])"
     )
     assert (
         str(ds[1:2])
-        == "Dataset(path=hub_pytest/test_api/test_stringify, index=Index([slice(1, 2, 1)]), tensors=['image'])"
+        == "Dataset(path='hub_pytest/test_api/test_stringify', index=Index([slice(1, 2, 1)]), tensors=['image'])"
     )
     assert str(ds.image) == "Tensor(key='image')"
     assert str(ds[1:2].image) == "Tensor(key='image', index=Index([slice(1, 2, 1)]))"
@@ -234,6 +235,24 @@ def test_compute_slices(memory_ds):
     _check_tensor(ds.data[:, :][0][(0, 1, 2), 0], data[:, :][0][(0, 1, 2), 0])
     _check_tensor(ds.data[0][(0, 1, 2), 0][1], data[0][(0, 1, 2), 0][1])
     _check_tensor(ds.data[:, :][0][(0, 1, 2), 0][1], data[:, :][0][(0, 1, 2), 0][1])
+
+
+def test_length_slices(memory_ds):
+    ds = memory_ds
+    data = np.array([1, 2, 3, 9, 8, 7, 100, 99, 98, 99, 101])
+    ds.create_tensor("data")
+    ds.data.extend(data)
+
+    assert len(ds) == 11
+    assert len(ds[0]) == 1
+    assert len(ds[0:1]) == 1
+    assert len(ds[0:0]) == 0
+    assert len(ds[1:10]) == 9
+    assert len(ds[1:7:2]) == 3
+    assert len(ds[1:8:2]) == 4
+    assert len(ds[1:9:2]) == 4
+    assert len(ds[1:10:2]) == 5
+    assert len(ds[[0, 1, 5, 9]]) == 4
 
 
 def test_shape_property(memory_ds):

--- a/hub/core/index/index.py
+++ b/hub/core/index/index.py
@@ -158,13 +158,36 @@ class IndexEntry:
         )
 
     def length(self, parent_length: int) -> int:
-        """Returns the length of an IndexEntry given the length of the parent it is indexing."""
-        if not self.subscriptable():
+        """Returns the length of an IndexEntry given the length of the parent it is indexing.
+
+        Examples:
+            >>> IndexEntry(slice(5, 10)).length(100)
+            5
+            >>> len(list(range(100))[5:10])
+            5
+            >>> IndexEntry(slice(5, 100)).length(50)
+            45
+            >>> len(list(range(50))[5:100])
+            45
+            >>> IndexEntry(0).length(10)
+            1
+
+        Args:
+            parent_length (int): The length of the target that this IndexEntry is indexing.
+
+        Returns:
+            int: The length of the index if it were applied to a parent of the given length.
+        """
+        if parent_length == 0:
+            return 0
+        elif not self.subscriptable():
             return 1
         elif isinstance(self.value, slice):
             return slice_length(self.value, parent_length)
         elif isinstance(self.value, tuple):
             return tuple_length(self.value, parent_length)
+        else:
+            return 0
 
 
 class Index:
@@ -298,7 +321,8 @@ class Index:
         return (len(self.values) == 1) and self.values[0].is_trivial()
 
     def length(self, parent_length: int):
-        """Returns the primary length of an Index given the length of the parent it is indexing."""
+        """Returns the primary length of an Index given the length of the parent it is indexing.
+        See: IndexEntry.length"""
         return self.values[0].length(parent_length)
 
     def __str__(self):

--- a/hub/core/index/index.py
+++ b/hub/core/index/index.py
@@ -67,7 +67,9 @@ def slice_at_int(s: slice, i: int):
 def slice_length(s: slice, parent_length: int) -> int:
     """Returns the length of a slice given the length of its parent."""
     start, stop, step = s.indices(parent_length)
-    step_offset = step - (1 if step > 0 else -1) # Used to ceil/floor depending on step direction
+    step_offset = step - (
+        1 if step > 0 else -1
+    )  # Used to ceil/floor depending on step direction
     slice_length = stop - start
     total_length = (slice_length + step_offset) // step
     return max(0, total_length)

--- a/hub/core/index/index.py
+++ b/hub/core/index/index.py
@@ -67,7 +67,10 @@ def slice_at_int(s: slice, i: int):
 def slice_length(s: slice, parent_length: int) -> int:
     """Returns the length of a slice given the length of its parent."""
     start, stop, step = s.indices(parent_length)
-    return max(0, (stop - start + (step - (1 if step > 0 else -1))) // step)
+    step_offset = step - (1 if step > 0 else -1) # Used to ceil/floor depending on step direction
+    slice_length = stop - start
+    total_length = (slice_length + step_offset) // step
+    return max(0, total_length)
 
 
 def tuple_length(t: Tuple[int], l: int) -> int:

--- a/hub/util/tests/test_split.py
+++ b/hub/util/tests/test_split.py
@@ -16,3 +16,8 @@ def test_split(memory_ds):
     assert train.ints.numpy().tolist() == expected_train
     assert test.ints.numpy().tolist() == expected_test
     assert val.ints.numpy().tolist() == expected_val
+
+    assert len(train) == 9
+    assert len(test) == 2
+    assert len(val) == 2
+    assert sum(map(len, (train, test, val))) == 13


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [x]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [x]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [x]  I have performed a self-review of my own code and resolved any problems
- [x]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [x]  New and existing unit tests pass locally with my changes


### Changes

Update `Dataset.__len__`, `Tensor.__len__` to account for length of an index. This is done via `Index.length` and `IndexEntry.length` (since they need the context for the length of the parent, they can't be `.__len__` methods)

```
>>> ds.data.numpy(aslist=True)
[1, 2, 3, 4, 5]
>>> len(ds[2:4])
2
>>> len(ds.data[[0,3]])
2
```

Bonus addition:
Add back the quotes to str(ds)'s path. `str(ds)` should now print `path` with the appropriate quotes.