### PR TITLE
Fix/2.0/scalars

### DIFF
--- a/hub/api/tests/test_api.py
+++ b/hub/api/tests/test_api.py
@@ -179,16 +179,38 @@ def test_empty_samples(ds: Dataset):
 @parametrize_all_dataset_storages
 def test_scalar_samples(ds: Dataset):
     tensor = ds.create_tensor("scalars")
+    assert tensor.meta.dtype == None
 
+    # first sample sets dtype
     tensor.append(5)
+    assert tensor.meta.dtype == "int64"
+
+    with pytest.raises(TensorDtypeMismatchError):
+        tensor.append(5.1)
+
     tensor.append(10)
     tensor.append(-99)
+    tensor.append(np.int64(4))
+
+    with pytest.raises(TensorDtypeMismatchError):
+        tensor.append(np.int32(4))
+
+    with pytest.raises(TensorDtypeMismatchError):
+        tensor.append(np.float32(4))
+
+    with pytest.raises(TensorDtypeMismatchError):
+        tensor.append(np.uint8(3))
+
     tensor.extend([10, 1, 4])
     tensor.extend([1])
+    tensor.extend(np.array([1, 2, 3], dtype="int64"))
 
-    assert len(tensor) == 7
+    with pytest.raises(TensorDtypeMismatchError):
+        tensor.extend(np.array([4, 5, 33], dtype="int32"))
 
-    expected = np.array([5, 10, -99, 10, 1, 4, 1])
+    assert len(tensor) == 11
+
+    expected = np.array([5, 10, -99, 4, 10, 1, 4, 1, 1, 2, 3])
     np.testing.assert_array_equal(tensor.numpy(), expected)
 
 

--- a/hub/core/tensor.py
+++ b/hub/core/tensor.py
@@ -152,7 +152,7 @@ def extend_tensor(
             )
 
     if not hasattr(samples, "__len__"):
-        raise ValueError(
+        raise TypeError(
             f"Provided `samples` '{samples}' does not have a `__len__` attribute, and thus cannot be used to extend. Try appending instead."
         )
 

--- a/hub/core/tensor.py
+++ b/hub/core/tensor.py
@@ -134,6 +134,7 @@ def extend_tensor(
 
     Raises:
         ValueError: If `samples` cannot be used to extend.
+        TypeError: If `samples` doesn't have a `__len__` property.
         TensorDoesNotExistError: If a tensor at `key` does not exist. A tensor must be created first using
             `create_tensor(...)`.
     """

--- a/hub/core/tensor.py
+++ b/hub/core/tensor.py
@@ -133,7 +133,7 @@ def extend_tensor(
             index_meta (IndexMeta): Optionally provide an `IndexMeta`. If not provided, it will be loaded from `storage`.
 
     Raises:
-        ValueError: If `array` has <= 1 axes.
+        ValueError: If `samples` cannot be used to extend.
         TensorDoesNotExistError: If a tensor at `key` does not exist. A tensor must be created first using
             `create_tensor(...)`.
     """
@@ -151,7 +151,13 @@ def extend_tensor(
                 f"An array with shape={samples.shape} cannot be used to extend because it's shape length is < 1."
             )
 
-        # TODO: may need to optimize this?
+    if not hasattr(samples, "__len__"):
+        raise ValueError(
+            f"Provided `samples` '{samples}' does not have a `__len__` attribute, and thus cannot be used to extend. Try appending instead."
+        )
+
+    if not isinstance(samples[0], Sample):
+        # TODO: need to optimize this
         samples = [Sample(array=samples[i]) for i in range(len(samples))]
 
     write_samples(samples, key, storage, tensor_meta, index_meta)


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### What is it?

fixes the following (and adds more robust test for):
```python
tensor.append(5)  # works fine already
tensor.append(np.int(5))  # failed before, now is supported
```

### Checklist:

- [ ]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [ ]  I have performed a self-review of my own code and resolved any problems
- [ ]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [ ]  New and existing unit tests pass locally with my changes


### Changes

<!-- Describe your changes! Describe the scope of this PR's responsibilities. -->
