### PR TITLE
set `USE_UNIFORM_COMPRESSION_PER_SAMPLE` to `True`

### DIFF
--- a/hub/constants.py
+++ b/hub/constants.py
@@ -15,7 +15,7 @@ SUPPORTED_COMPRESSIONS = ["png", "jpeg", UNCOMPRESSED]
 
 # If `True`  compression format has to be the same between samples in the same tensor.
 # If `False` compression format can   be different between samples in the same tensor.
-USE_UNIFORM_COMPRESSION_PER_SAMPLE = False
+USE_UNIFORM_COMPRESSION_PER_SAMPLE = True
 
 SUPPORTED_MODES = ["r", "a"]
 CHUNK_MAX_SIZE = (


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### What is it?

with `USE_UNIFORM_COMPRESSION_PER_SAMPLE = True` this means that all compressed samples being ingested are decompressed and recompressed to keep tensor uniformity. This flag will simplify our development process, as well as move further away from a generic filesystem.

on the other hand, if `False`, ingestion is faster.

This PR proposes to keep tensor uniformity. 

### Checklist:

- [ ]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [ ]  I have performed a self-review of my own code and resolved any problems
- [ ]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [ ]  New and existing unit tests pass locally with my changes


### Changes

<!-- Describe your changes! Describe the scope of this PR's responsibilities. -->
