### PR TITLE
[2.0] Remove dataclass from index.py

### DIFF
--- a/hub/core/index/index.py
+++ b/hub/core/index/index.py
@@ -1,5 +1,4 @@
 from typing import Union, List, Tuple, Iterable, Optional, TypeVar
-from dataclasses import dataclass
 import numpy as np
 
 IndexValue = Union[int, slice, Tuple[int]]
@@ -80,9 +79,9 @@ def tuple_length(t: Tuple[int], l: int) -> int:
     return sum(1 for _ in filter(lambda i: i < l, t))
 
 
-@dataclass
 class IndexEntry:
-    value: IndexValue = slice(None)
+    def __init__(self, value: IndexValue = slice(None)):
+        self.value = value
 
     def __getitem__(self, item: IndexValue):
         """Combines the given `item` and this IndexEntry.


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [x]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [x]  I have commented my code, particularly in hard-to-understand areas
- [x]  I have kept the `coverage-rate` up
- [x]  I have performed a self-review of my own code and resolved any problems
- [x]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [x]  I have described and made corresponding changes to the relevant documentation
- [x]  New and existing unit tests pass locally with my changes


### Changes

Removes usage of `@dataclass` for python 3.7 compatibility.