### PR TITLE
[2.0] Alias __repr__ to __str__ for Dataset and Tensor

### DIFF
--- a/hub/api/dataset.py
+++ b/hub/api/dataset.py
@@ -346,6 +346,8 @@ class Dataset:
 
         return f"Dataset({path_str}{mode_str}{index_str}tensors={self.meta.tensors})"
 
+    __repr__ = __str__
+
     @property
     def token(self):
         """Get attached token of the dataset"""

--- a/hub/api/tensor.py
+++ b/hub/api/tensor.py
@@ -227,3 +227,5 @@ class Tensor:
         if self.index.is_trivial():
             index_str = ""
         return f"Tensor(key={repr(self.key)}{index_str})"
+
+    __repr__ = __str__


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [x]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [x]  I have commented my code, particularly in hard-to-understand areas
- [x]  I have kept the `coverage-rate` up
- [x]  I have performed a self-review of my own code and resolved any problems
- [x]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [x]  I have described and made corresponding changes to the relevant documentation
- [x]  New and existing unit tests pass locally with my changes


### Changes

When in a python REPL environment, Dataset isn't printed according to `__str__`, but actually `__repr__`. We may want to diverge these in the future, but for now we should alias them so it doesn't print as:
```
>>> ds
<Dataset object at 0x7f0e47de7670>
```