### PR TITLE
Remove readonly check on S3 __getitem__

### DIFF
--- a/hub/core/storage/s3.py
+++ b/hub/core/storage/s3.py
@@ -119,7 +119,6 @@ class S3Provider(StorageProvider):
             S3GetError: Any other error other than KeyError while retrieving the object.
             ReadOnlyError: If the provider is in read-only mode.
         """
-        self.check_readonly()
         self._check_update_creds()
         try:
             path = posixpath.join(self.path, path)


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [x]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [x]  I have commented my code, particularly in hard-to-understand areas
- [x]  I have kept the `coverage-rate` up
- [x]  I have performed a self-review of my own code and resolved any problems
- [x]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [x]  I have described and made corresponding changes to the relevant documentation
- [x]  New and existing unit tests pass locally with my changes


### Changes

A readonly check was mistakenly included in `S3.__getitem__`, which doesn't modify and therefore is readonly-safe. This PR removes the throw here.