### PR TITLE
[2.0] Minor improvements to docstrings

### DIFF
--- a/hub/api/dataset.py
+++ b/hub/api/dataset.py
@@ -153,7 +153,7 @@ class Dataset:
         chunk_compression: str = None,
         **kwargs,
     ):
-        """Creates a new tensor in a dataset.
+        """Creates a new tensor in the dataset.
 
         Args:
             name (str): The name of the tensor to be created.
@@ -274,7 +274,10 @@ class Dataset:
         }
 
     def tensorflow(self):
-        """Converts the dataset into a pytorch compatible format.
+        """Converts the dataset into a tensorflow compatible format.
+
+        See:
+            https://www.tensorflow.org/api_docs/python/tf/data/Dataset
 
         Returns:
             tf.data.Dataset object that can be used for tensorflow training.

--- a/hub/api/tensor.py
+++ b/hub/api/tensor.py
@@ -47,7 +47,7 @@ class Tensor:
             raise TensorDoesNotExistError(self.key)
 
     def extend(self, samples: Union[np.ndarray, Sequence, Sequence[Sample]]):
-        """Extends the end of a tensor by appending multiple elements from a sequence. Accepts a sequence, a single batched numpy array,
+        """Extends the end of the tensor by appending multiple elements from a sequence. Accepts a sequence, a single batched numpy array,
         or a sequence of `hub.load` outputs, which can be used to load files. See examples down below.
 
         Example:
@@ -84,7 +84,7 @@ class Tensor:
         self,
         sample: Union[np.ndarray, float, int, Sequence, Sample],
     ):
-        """Appends a single sample to the end of a tensor. Can be an array, scalar value, or the return value from `hub.load`,
+        """Appends a single sample to the end of the tensor. Can be an array, scalar value, or the return value from `hub.load`,
         which can be used to load files. See examples down below.
 
         Examples:
@@ -171,7 +171,7 @@ class Tensor:
         return self.shape_interval.is_dynamic
 
     def __len__(self):
-        """Returns the length of the primary axis of a tensor.
+        """Returns the length of the primary axis of the tensor.
         Accounts for indexing into the tensor object.
 
         Examples:
@@ -204,7 +204,7 @@ class Tensor:
             yield self[i]
 
     def numpy(self, aslist=False) -> Union[np.ndarray, List[np.ndarray]]:
-        """Computes the contents of a tensor in numpy format.
+        """Computes the contents of the tensor in numpy format.
 
         Args:
             aslist (bool): If True, a list of np.ndarrays will be returned. Helpful for dynamic tensors.

--- a/hub/util/get_storage_provider.py
+++ b/hub/util/get_storage_provider.py
@@ -42,10 +42,10 @@ def storage_provider_from_path(
         token (str): token for authentication into activeloop
 
     Returns:
-        If given a valid S3 path i.e starts with s3:// returns the S3Provider and mode. (credentials should either be in creds or the environment)
-        If given a path starting with mem://return the MemoryProvider and mode.
-        If given a valid local path, return the LocalProvider and mode.
-
+        If given a path starting with s3://  returns the S3Provider.
+        If given a path starting with mem:// returns the MemoryProvider.
+        If given a path starting with hub:// returns the underlying cloud Provider.
+        If given a valid local path, returns the LocalProvider.
 
     Raises:
         ValueError: If the given path is a local path to a file.


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [x]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [x]  I have commented my code, particularly in hard-to-understand areas
- [x]  I have kept the `coverage-rate` up
- [x]  I have performed a self-review of my own code and resolved any problems
- [x]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [x]  I have described and made corresponding changes to the relevant documentation
- [x]  New and existing unit tests pass locally with my changes


### Changes

- Unify wording in Dataset/Tensor: "verbs _the_ dataset" instead of "verbs _a_ dataset". This may or may not be in line with google-docstring standard, but it's consistent with what we have elsewhere.
- Tensorflow docstring should say "tensorflow" and not "pytorch". Also added a link to the `tf.data.Dataset` docs
- Add `hub://` to the docstring for `storage_provider_from_path`, and update the wording.