### PR TITLE
[2.0] Support compression for grayscale images

### DIFF
--- a/hub/api/tests/test_api_with_compression.py
+++ b/hub/api/tests/test_api_with_compression.py
@@ -98,8 +98,6 @@ def test_uncompressed(ds: Dataset):
 @pytest.mark.parametrize(
     "bad_shape",
     [
-        # raises TypeError: Cannot handle this data type: (1, 1, 1), |u1
-        (100, 100, 1),
         # raises OSError: cannot write mode LA as JPEG
         (100, 100, 2),
         # raises OSError: cannot write mode RGBA as JPE
@@ -112,7 +110,7 @@ def test_jpeg_bad_shapes(memory_ds: Dataset, bad_shape):
     # (100) works!
     # (100,) works!
     # (100, 100) works!
-    # (100, 100, 1) raises   | TypeError: Cannot handle this data type: (1, 1, 1), |u1
+    # (100, 100, 1) works!
     # (100, 100, 2) raises   | OSError: cannot write mode LA as JPEG
     # (100, 100, 3) works!
     # (100, 100, 4) raises   | OSError: cannot write mode RGBA as JPEG

--- a/hub/core/chunk_engine/read.py
+++ b/hub/core/chunk_engine/read.py
@@ -30,16 +30,17 @@ def sample_from_index_entry(
     mv = buffer_from_index_entry(key, storage, index_entry)
     is_empty = len(mv) <= 0
 
+    shape = index_entry["shape"]
     if is_empty or tensor_meta.sample_compression == UNCOMPRESSED:
         # TODO: chunk-wise compression
 
         return array_from_buffer(
             mv,
             tensor_meta.dtype,
-            shape=index_entry["shape"],
+            shape=shape,
         )
 
-    return decompress_array(mv)
+    return decompress_array(mv, shape=shape)
 
 
 def buffer_from_index_entry(

--- a/hub/core/compression.py
+++ b/hub/core/compression.py
@@ -4,11 +4,20 @@ from hub.util.exceptions import (
     SampleDecompressionError,
     UnsupportedCompressionError,
 )
-from typing import Union
+from typing import Union, Tuple
 import numpy as np
 
 from PIL import Image, UnidentifiedImageError  # type: ignore
 from io import BytesIO
+
+
+def to_image(array: np.ndarray) -> Image:
+    shape = array.shape
+    if len(shape) == 3 and shape[0] != 1 and shape[2] == 1:
+        # convert (X,Y,1) grayscale to (X,Y) for pillow compatibility
+        return Image.fromarray(array.squeeze(axis=2))
+
+    return Image.fromarray(array)
 
 
 def compress_array(array: np.ndarray, compression: str) -> bytes:
@@ -33,7 +42,7 @@ def compress_array(array: np.ndarray, compression: str) -> bytes:
         raise UnsupportedCompressionError(compression)
 
     try:
-        img = Image.fromarray(array)
+        img = to_image(array)
         out = BytesIO()
         img.save(out, compression)
         out.seek(0)
@@ -42,7 +51,7 @@ def compress_array(array: np.ndarray, compression: str) -> bytes:
         raise SampleCompressionError(array.shape, compression, str(e))
 
 
-def decompress_array(buffer: Union[bytes, memoryview]) -> np.ndarray:
+def decompress_array(buffer: Union[bytes, memoryview], shape: Tuple[int]) -> np.ndarray:
     """Decompress some buffer into a numpy array. It is expected that all meta information is
     stored inside `buffer`.
 
@@ -52,6 +61,7 @@ def decompress_array(buffer: Union[bytes, memoryview]) -> np.ndarray:
     Args:
         buffer (bytes, memoryview): Buffer to be decompressed. It is assumed all meta information required to
             decompress is contained within `buffer`.
+        shape (Tuple[int]): Desired shape of decompressed object. Reshape will attempt to match this shape before returning.
 
     Raises:
         SampleDecompressionError: Right now only buffers compatible with `PIL` will be decompressed.
@@ -62,6 +72,6 @@ def decompress_array(buffer: Union[bytes, memoryview]) -> np.ndarray:
 
     try:
         img = Image.open(BytesIO(buffer))
-        return np.array(img)
+        return np.array(img).reshape(shape)
     except UnidentifiedImageError:
         raise SampleDecompressionError()

--- a/hub/core/sample.py
+++ b/hub/core/sample.py
@@ -90,7 +90,6 @@ class Sample:
             bytes: Bytes for the compressed sample. Contains all metadata required to decompress within these bytes.
         """
 
-        # TODO: raise a comprehensive error for unsupported compression types
         compression = compression.lower()
 
         if compression == UNCOMPRESSED:

--- a/hub/core/tests/test_compression.py
+++ b/hub/core/tests/test_compression.py
@@ -11,12 +11,18 @@ parametrize_compressions = pytest.mark.parametrize(
     "compression", ["jpeg", "png"]
 )  # TODO: extend to be all pillow types we want to focus on
 
+parametrize_image_shapes = pytest.mark.parametrize(
+    "shape",
+    [(100, 100, 3), (28, 28, 1), (32, 32)],  # JPEG does not support RGBA
+)
+
 
 @parametrize_compressions
-def test_array(compression):
+@parametrize_image_shapes
+def test_array(compression, shape):
     # TODO: check dtypes and no information loss
-    array = np.zeros((100, 100, 3), dtype="uint8")  # TODO: handle non-uint8
+    array = np.zeros(shape, dtype="uint8")  # TODO: handle non-uint8
     compressed_buffer = compress_array(array, compression)
     assert get_actual_compression_from_buffer(compressed_buffer) == compression
-    decompressed_array = decompress_array(compressed_buffer)
+    decompressed_array = decompress_array(compressed_buffer, shape=shape)
     np.testing.assert_array_equal(array, decompressed_array)

--- a/hub/integrations/pytorch.py
+++ b/hub/integrations/pytorch.py
@@ -204,7 +204,7 @@ class TorchDataset:
         if sample_compression == UNCOMPRESSED:
             arr = np.frombuffer(combined_bytes, dtype=dtype).reshape(shape)
         else:
-            arr = decompress_array(combined_bytes)
+            arr = decompress_array(combined_bytes, shape=shape)
 
         if isinstance(combined_bytes, memoryview):
             combined_bytes.release()


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [x]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [x]  I have commented my code, particularly in hard-to-understand areas
- [x]  I have kept the `coverage-rate` up
- [x]  I have performed a self-review of my own code and resolved any problems
- [x]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [x]  New and existing unit tests pass locally with my changes


### Changes

- Enables compression of grayscale images by squeezing the last dimension (assumed to be the channel dimension) when unambiguous, and restoring the shape when decompressing.