### PR TITLE
Fix/2.0/login message

### DIFF
--- a/hub/cli/auth.py
+++ b/hub/cli/auth.py
@@ -19,7 +19,8 @@ from hub.util.exceptions import AuthenticationException
 @click.option("--password", "-p", default=None, help="Your Activeloop Password")
 def login(username: str, password: str):
     """Log in to Activeloop"""
-    if username is None:
+    # If any/all argument values are None, request the user to enter credentials
+    if all([username, password]) == False:
         click.echo("Login to Activeloop Hub using your credentials.")
         click.echo(
             "If you don't have an account, register by using the 'activeloop register' command or by going to "
@@ -70,7 +71,7 @@ def reporting(on):
 @click.option("--password", "-p", default=None, help="Your Activeloop Password")
 def register(username: str, email: str, password: str):
     """Create a new Activeloop user account"""
-    # If any/all argument values are None, we request the user to enter credentials
+    # If any/all argument values are None, request the user to enter credentials
     if all([username, email, password]) == False:
         click.echo(
             "Enter your details. Your password must be atleast 6 characters long."

--- a/hub/cli/auth.py
+++ b/hub/cli/auth.py
@@ -20,7 +20,7 @@ from hub.util.exceptions import AuthenticationException
 def login(username: str, password: str):
     """Log in to Activeloop"""
     if not username:
-        click.echo("Login to Activeloop Hub using your credentials.")
+        click.echo("Login to Activeloop using your credentials.")
         click.echo(
             "If you don't have an account, register by using the 'activeloop register' command or by going to "
             f"{HUB_REST_ENDPOINT}/register."
@@ -37,7 +37,7 @@ def login(username: str, password: str):
         client = HubBackendClient()
         token = client.request_auth_token(username, password)
         write_token(token)
-        click.echo("Successfully logged in to Activeloop Hub.")
+        click.echo("Successfully logged in to Activeloop.")
         reporting_config = get_reporting_config()
         if reporting_config.get("username") != username:
             save_reporting_config(True, username=username)
@@ -51,7 +51,7 @@ def login(username: str, password: str):
 def logout():
     """Log out of Activeloop"""
     remove_token()
-    click.echo("Logged out of Activeloop Hub.")
+    click.echo("Logged out of Activeloop.")
 
 
 # TODO: Add how to enable/disable reporting to docs
@@ -100,7 +100,7 @@ def register(username: str, email: str, password: str):
         token = client.request_auth_token(username, password)
         write_token(token)
         click.echo(
-            f"Successfully registered and logged in to Activeloop Hub as {username}."
+            f"Successfully registered and logged in to Activeloop as {username}."
         )
         consent_message = textwrap.dedent(
             """

--- a/hub/cli/auth.py
+++ b/hub/cli/auth.py
@@ -20,8 +20,6 @@ from hub.util.exceptions import AuthenticationException
 def login(username: str, password: str):
     """Log in to Activeloop"""
     if not username:
-        # Setting all other arguments to None as username not provided
-        password = None
         click.echo("Login to Activeloop Hub using your credentials.")
         click.echo(
             "If you don't have an account, register by using the 'activeloop register' command or by going to "
@@ -76,11 +74,8 @@ def reporting(on):
 @click.option("--password", "-p", default=None, help="Your Activeloop Password")
 def register(username: str, email: str, password: str):
     """Create a new Activeloop user account"""
-    # If any/all argument values are None, request the user to enter credentials
     click.echo("Thank you for registering for an Activeloop account!")
     if not username:
-        password = None
-        email = None
         click.echo(
             "Enter your details. Your password must be atleast 6 characters long."
         )

--- a/hub/cli/auth.py
+++ b/hub/cli/auth.py
@@ -15,24 +15,25 @@ from hub.util.exceptions import AuthenticationException
 
 
 @click.command()
-@click.option("--username", "-u", default=None, help="Your Activeloop username")
-@click.option("--password", "-p", default=None, help="Your Activeloop password")
+@click.option("--username", "-u", default=None, help="Your Activeloop Username")
+@click.option("--password", "-p", default=None, help="Your Activeloop Password")
 def login(username: str, password: str):
     """Log in to Activeloop"""
-    click.echo("Login to Activeloop Hub using your credentials.")
-    click.echo(
-        "If you don't have an account, register by using 'activeloop register' command or by going to "
-        f"{HUB_REST_ENDPOINT}/register."
-    )
-    username = username or click.prompt("Username")
+    if username is None:
+        click.echo("Login to Activeloop Hub using your credentials.")
+        click.echo(
+            "If you don't have an account, register by using the 'activeloop register' command or by going to "
+            f"{HUB_REST_ENDPOINT}/register."
+        )
+        username = click.prompt("Username")
+        password = click.prompt("Password", hide_input=True)
     username = username.strip()
-    password = password or click.prompt("Password", hide_input=True)
     password = password.strip()
     try:
         client = HubBackendClient()
         token = client.request_auth_token(username, password)
         write_token(token)
-        click.echo("\nSuccessfully logged in to Activeloop Hub.")
+        click.echo("Successfully logged in to Activeloop Hub.")
         reporting_config = get_reporting_config()
         if reporting_config.get("username") != username:
             save_reporting_config(True, username=username)
@@ -46,7 +47,7 @@ def login(username: str, password: str):
 def logout():
     """Log out of Activeloop"""
     remove_token()
-    click.echo("Logged out of Hub.")
+    click.echo("Logged out of Activeloop Hub.")
 
 
 # TODO: Add how to enable/disable reporting to docs
@@ -64,17 +65,21 @@ def reporting(on):
 
 
 @click.command()
-@click.option("--username", "-u", default=None, help="Your Activeloop username")
-@click.option("--email", "-e", default=None, help="Your email")
-@click.option("--password", "-p", default=None, help="Your Activeloop password")
+@click.option("--username", "-u", default=None, help="Your Activeloop Username")
+@click.option("--email", "-e", default=None, help="Your Email")
+@click.option("--password", "-p", default=None, help="Your Activeloop Password")
 def register(username: str, email: str, password: str):
     """Create a new Activeloop user account"""
-    click.echo("Enter your details. Your password must be atleast 6 characters long.")
-    username = username or click.prompt("Username")
+    # If any/all argument values are None, we request the user to enter credentials
+    if all([username, email, password]) == False:
+        click.echo(
+            "Enter your details. Your password must be atleast 6 characters long."
+        )
+        username = click.prompt("Username")
+        email = click.prompt("Email")
+        password = click.prompt("Password", hide_input=True)
     username = username.strip()
-    email = email or click.prompt("Email")
     email = email.strip()
-    password = password or click.prompt("Password", hide_input=True)
     password = password.strip()
     try:
         client = HubBackendClient()

--- a/hub/cli/test_cli.py
+++ b/hub/cli/test_cli.py
@@ -16,10 +16,7 @@ def test_cli_auth():
     password = os.getenv("ACTIVELOOP_HUB_PASSWORD")
     result = runner.invoke(login, f"-u {username} -p {password}")
     assert result.exit_code == 0
-    assert (
-        result.output
-        == "Successfully logged in to Activeloop Hub.\n"
-    )
+    assert result.output == "Successfully logged in to Activeloop Hub.\n"
 
     result = runner.invoke(logout)
     assert result.exit_code == 0

--- a/hub/cli/test_cli.py
+++ b/hub/cli/test_cli.py
@@ -16,8 +16,8 @@ def test_cli_auth():
     password = os.getenv("ACTIVELOOP_HUB_PASSWORD")
     result = runner.invoke(login, f"-u {username} -p {password}")
     assert result.exit_code == 0
-    assert result.output == "Successfully logged in to Activeloop Hub.\n"
+    assert result.output == "Successfully logged in to Activeloop.\n"
 
     result = runner.invoke(logout)
     assert result.exit_code == 0
-    assert result.output == "Logged out of Activeloop Hub.\n"
+    assert result.output == "Logged out of Activeloop.\n"

--- a/hub/cli/test_cli.py
+++ b/hub/cli/test_cli.py
@@ -18,10 +18,9 @@ def test_cli_auth():
     assert result.exit_code == 0
     assert (
         result.output
-        == "Login to Activeloop Hub using your credentials.\nIf you don't have an account, register by using 'activeloop register' command or by going to "
-        f"{HUB_REST_ENDPOINT}/register.\n\nSuccessfully logged in to Activeloop Hub.\n"
+        == "Successfully logged in to Activeloop Hub.\n"
     )
 
     result = runner.invoke(logout)
     assert result.exit_code == 0
-    assert result.output == "Logged out of Hub.\n"
+    assert result.output == "Logged out of Activeloop Hub.\n"


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [X]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [X]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [X]  I have performed a self-review of my own code and resolved any problems
- [X]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [X]  I have described and made corresponding changes to the relevant documentation
- [X]  New and existing unit tests pass locally with my changes


### Changes

<!-- Describe your changes! Describe the scope of this PR's responsibilities. -->
Added an extra case in the `activeloop login`/ `activeloop register` commands where the extra "Log in with your credentials" message is not shown if the user executes the command with command line arguments. 