### PR TITLE
Optimizes pytorch transforms to use shared memory

### DIFF
--- a/hub/integrations/tests/test_pytorch.py
+++ b/hub/integrations/tests/test_pytorch.py
@@ -145,6 +145,41 @@ def test_pytorch_large(ds):
 
 @requires_torch
 @parametrize_all_dataset_storages
+def test_pytorch_transform(ds):
+    import torch
+
+    with ds:
+        ds.create_tensor("image")
+        ds.image.extend(np.array([i * np.ones((300, 300)) for i in range(256)]))
+        ds.create_tensor("image2")
+        ds.image2.extend(np.array([i * np.ones((100, 100)) for i in range(256)]))
+
+    def to_tuple(sample):
+        return sample["image"], sample["image2"]
+
+    if isinstance(remove_memory_cache(ds.storage), MemoryProvider):
+        with pytest.raises(DatasetUnsupportedPytorch):
+            ptds = ds.pytorch(workers=2)
+        return
+
+    ptds = ds.pytorch(workers=2, transform=to_tuple)
+    dl = torch.utils.data.DataLoader(
+        ptds,
+        batch_size=1,
+        num_workers=0,
+    )
+
+    for i, batch in enumerate(dl):
+        actual_image = batch[0].numpy()
+        expected_image = i * np.ones((1, 300, 300))
+        actual_image2 = batch[1].numpy()
+        expected_image2 = i * np.ones((1, 100, 100))
+        np.testing.assert_array_equal(actual_image, expected_image)
+        np.testing.assert_array_equal(actual_image2, expected_image2)
+
+
+@requires_torch
+@parametrize_all_dataset_storages
 def test_pytorch_with_compression(ds: Dataset):
     import torch
 


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [x]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [x]  I have performed a self-review of my own code and resolved any problems
- [x]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [x]  I have described and made corresponding changes to the relevant documentation
- [x]  New and existing unit tests pass locally with my changes


### Changes
Currently, hub to pytorch is quite fast but it slows down to v1 speeds if a transform function is passed.
The slowdown is due to pickling overhead due to Python multiprocessing.
This PR optimizes pytorch transform to use shared memory and thus removes this slowdown.
