### PR TITLE
[2.0] Update transform test to include bad meta bug

### DIFF
--- a/hub/core/transform/test_transform.py
+++ b/hub/core/transform/test_transform.py
@@ -30,8 +30,8 @@ def test_single_transform_hub_dataset(ds):
     with Dataset("./test/transform_hub_in") as data_in:
         data_in.create_tensor("image")
         data_in.create_tensor("label")
-        for i in range(100):
-            data_in.image.append(i * np.ones((100, 100)))
+        for i in range(1, 100):
+            data_in.image.append(i * np.ones((i, i)))
             data_in.label.append(i * np.ones((1,)))
     data_in = Dataset("./test/transform_hub_in")
     ds_out = ds
@@ -39,14 +39,17 @@ def test_single_transform_hub_dataset(ds):
     ds_out.create_tensor("label")
     transform(data_in, [fn2], ds_out)
     data_in.delete()
-    assert len(ds_out) == 100
-    for index in range(100):
+    assert len(ds_out) == 99
+    for index in range(1, 100):
         np.testing.assert_array_equal(
-            ds_out[index].image.numpy(), index * np.ones((100, 100))
+            ds_out[index - 1].image.numpy(), index * np.ones((index, index))
         )
         np.testing.assert_array_equal(
-            ds_out[index].label.numpy(), index * np.ones((1,))
+            ds_out[index - 1].label.numpy(), index * np.ones((1,))
         )
+
+    assert ds_out.image.shape_interval.lower == (99, 1, 1)
+    assert ds_out.image.shape_interval.upper == (99, 100, 100)
 
 
 @parametrize_all_dataset_storages


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [x]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [x]  I have commented my code, particularly in hard-to-understand areas
- [x]  I have kept the `coverage-rate` up
- [x]  I have performed a self-review of my own code and resolved any problems
- [ ]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [x]  I have described and made corresponding changes to the relevant documentation
- [ ]  New and existing unit tests pass locally with my changes


### Changes

Modifies the transform test to use dynamic shapes and test that the shape range is set correctly. It isn't.
I don't have a fix, so I'm adding the test and handing off the task.