### PR TITLE
[2.0] Switch Dataset.delete to Dataset.__del__

### DIFF
--- a/hub/api/dataset.py
+++ b/hub/api/dataset.py
@@ -304,14 +304,22 @@ class Dataset:
         if hasattr(self.storage, "clear_cache"):
             self.storage.clear_cache()
 
-    def delete(self):
+    def __del__(self):
         """Deletes the entire dataset from the cache layers (if any) and the underlying storage.
-        This is an IRREVERSIBLE operation. Data once deleted can not be recovered.
+        This is an IRREVERSIBLE operation. Deleted data is not recoverable.
         """
         self.storage.clear()
         if self.path.startswith("hub://"):
             self.client.delete_dataset_entry(self.org_id, self.ds_name)
             logger.info(f"Hub Dataset {self.path} successfully deleted.")
+
+    @staticmethod
+    def delete(path: str):
+        """Deletes the dataset at a given path, if it exists.
+        This is an IRREVERSIBLE operation. Deleted data is not recoverable.
+        """
+        ds = Dataset(path, memory_cache_size=0, local_cache_size=0)
+        del ds
 
     @staticmethod
     def from_path(path: str):

--- a/hub/api/tests/test_api.py
+++ b/hub/api/tests/test_api.py
@@ -25,7 +25,7 @@ def test_persist_local(local_storage):
     assert ds_new.image.shape == (4, 4096, 4096)
 
     np.testing.assert_array_equal(ds_new.image.numpy(), np.ones((4, 4096, 4096)))
-    ds.delete()
+    del ds
 
 
 def test_persist_with_local(local_storage):
@@ -45,7 +45,7 @@ def test_persist_with_local(local_storage):
     assert ds_new.image.shape == (4, 4096, 4096)
 
     np.testing.assert_array_equal(ds_new.image.numpy(), np.ones((4, 4096, 4096)))
-    ds.delete()
+    del ds
 
 
 def test_persist_local_clear_cache(local_storage):
@@ -62,7 +62,7 @@ def test_persist_local_clear_cache(local_storage):
     assert ds_new.image.shape == (4, 4096, 4096)
 
     np.testing.assert_array_equal(ds_new.image.numpy(), np.ones((4, 4096, 4096)))
-    ds.delete()
+    del ds
 
 
 @parametrize_all_dataset_storages
@@ -421,4 +421,4 @@ def test_hub_cloud_dataset():
     for i in range(10):
         np.testing.assert_array_equal(ds.image[i].numpy(), i * np.ones((100, 100)))
 
-    ds.delete()
+    del ds

--- a/hub/core/transform/test_transform.py
+++ b/hub/core/transform/test_transform.py
@@ -38,7 +38,7 @@ def test_single_transform_hub_dataset(ds):
     ds_out.create_tensor("image")
     ds_out.create_tensor("label")
     transform(data_in, [fn2], ds_out)
-    data_in.delete()
+    del data_in
     assert len(ds_out) == 100
     for index in range(100):
         np.testing.assert_array_equal(

--- a/hub/integrations/tests/test_tensorflow.py
+++ b/hub/integrations/tests/test_tensorflow.py
@@ -42,7 +42,7 @@ def test_tensorflow_small(local_ds):
         # converting tf Tensors to numpy
         np.testing.assert_array_equal(batch["image"].numpy(), i * np.ones((300, 300)))
         np.testing.assert_array_equal(batch["image2"].numpy(), i * np.ones((100, 100)))
-    local_ds.delete()
+    del local_ds
 
 
 @requires_tensorflow
@@ -68,4 +68,4 @@ def test_tensorflow_large(local_ds):
             batch["image"].numpy(), (i + 1) * np.ones((4096, 4096))
         )
         np.testing.assert_array_equal(batch["classlabel"].numpy(), (i) * np.ones((1,)))
-    local_ds.delete()
+    del local_ds

--- a/hub/util/get_storage_provider.py
+++ b/hub/util/get_storage_provider.py
@@ -66,6 +66,7 @@ def storage_provider_from_path(
     elif path.startswith("hub://"):
         storage = storage_provider_from_hub_path(path, read_only, token=token)
     else:
+        path = os.path.expanduser(path)
         if not os.path.exists(path) or os.path.isdir(path):
             storage = LocalProvider(path)
         else:


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [x]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [x]  I have commented my code, particularly in hard-to-understand areas
- [x]  I have kept the `coverage-rate` up
- [x]  I have performed a self-review of my own code and resolved any problems
- [x]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [x]  New and existing unit tests pass locally with my changes


### Changes

Switch to python's built-in deletion syntax `del ds`. Note that this destroys the name and a NameError will occur if you try to further access the object. A static `Dataset.delete(path)` is also provided for utility; we may consider replacing this with an `overwrite` flag in the future.