### PR TITLE
[2.0] Better negative indexing

### DIFF
--- a/hub/api/tests/test_api.py
+++ b/hub/api/tests/test_api.py
@@ -293,6 +293,10 @@ def test_compute_slices(memory_ds):
     _check_tensor(ds.data[:, :][0][(0, 1, 2), 0][1], data[:, :][0][(0, 1, 2), 0][1])
     _check_tensor(ds.data[::-1], data[::-1])
     _check_tensor(ds.data[::-3], data[::-3])
+    _check_tensor(ds.data[::-3][4], data[::-3][4])
+    _check_tensor(ds.data[-2:], data[-2:])
+    _check_tensor(ds.data[-6:][3], data[-6:][3])
+    _check_tensor(ds.data[:-6:][3], data[:-6:][3])
 
 
 def test_length_slices(memory_ds):

--- a/hub/api/tests/test_api.py
+++ b/hub/api/tests/test_api.py
@@ -6,6 +6,7 @@ import hub
 import os
 from hub.api.dataset import Dataset
 from hub.core.tests.common import parametrize_all_dataset_storages
+from hub.tests.common import assert_array_lists_equal
 from hub.util.exceptions import TensorDtypeMismatchError
 from hub.client.client import HubBackendClient
 from hub.client.utils import has_hub_testing_creds
@@ -97,10 +98,10 @@ def test_stringify(memory_ds):
     )
     assert (
         str(ds[1:2])
-        == "Dataset(path='hub_pytest/test_api/test_stringify', index=Index([slice(1, 2, 1)]), tensors=['image'])"
+        == "Dataset(path='hub_pytest/test_api/test_stringify', index=Index([slice(1, 2, None)]), tensors=['image'])"
     )
     assert str(ds.image) == "Tensor(key='image')"
-    assert str(ds[1:2].image) == "Tensor(key='image', index=Index([slice(1, 2, 1)]))"
+    assert str(ds[1:2].image) == "Tensor(key='image', index=Index([slice(1, 2, None)]))"
 
 
 def test_stringify_with_path(local_ds):
@@ -134,8 +135,13 @@ def test_compute_dynamic_tensor(ds):
     actual_list = image.numpy(aslist=True)
 
     assert type(actual_list) == list
-    for expected, actual in zip(expected_list, actual_list):
-        np.testing.assert_array_equal(expected, actual)
+    assert_array_lists_equal(expected_list, actual_list)
+
+    # test negative indexing
+    np.testing.assert_array_equal(expected_list[-1], image[-1].numpy())
+    np.testing.assert_array_equal(expected_list[-2], image[-2].numpy())
+    assert_array_lists_equal(expected_list[-2:], image[-2:].numpy(aslist=True))
+    assert_array_lists_equal(expected_list[::-3], image[::-3].numpy(aslist=True))
 
     assert image.shape == (43, None, None)
     assert image.shape_interval.lower == (43, 28, 10)
@@ -167,8 +173,7 @@ def test_empty_samples(ds: Dataset):
     assert tensor.shape_interval.lower == (16, 0, 0, 2)
     assert tensor.shape_interval.upper == (16, 25, 50, 2)
 
-    for actual, expected in zip(actual_list, expected_list):
-        np.testing.assert_array_equal(actual, expected)
+    assert_array_lists_equal(actual_list, expected_list)
 
     # test indexing individual empty samples with numpy while looping, this may seem redundant but this was failing before
     for actual_sample, expected in zip(ds, expected_list):
@@ -229,8 +234,7 @@ def test_sequence_samples(ds: Dataset):
     np.testing.assert_array_equal(tensor.numpy(), expected)
 
     assert type(tensor.numpy(aslist=True)) == list
-    np.testing.assert_array_equal(tensor.numpy(aslist=True)[0], np.array([1, 2, 3]))
-    np.testing.assert_array_equal(tensor.numpy(aslist=True)[1], np.array([4, 5, 6]))
+    assert_array_lists_equal(tensor.numpy(aslist=True), expected)
 
 
 @parametrize_all_dataset_storages
@@ -265,11 +269,12 @@ def test_compute_slices(memory_ds):
     _check_tensor(ds.data[10:20], data[10:20])
     _check_tensor(ds.data[5], data[5])
     _check_tensor(ds.data[0][:], data[0][:])
+    _check_tensor(ds.data[-1][:], data[-1][:])
     _check_tensor(ds.data[3, 3], data[3, 3])
     _check_tensor(ds.data[30:40, :, 8:11, 4], data[30:40, :, 8:11, 4])
     _check_tensor(ds.data[16, 4, 5, 1:3], data[16, 4, 5, 1:3])
     _check_tensor(ds[[0, 1, 2, 5, 6, 10, 60]].data, data[[0, 1, 2, 5, 6, 10, 60]])
-    _check_tensor(ds.data[[0, 1, 2, 5, 6, 10, 60]], data[[0, 1, 2, 5, 6, 10, 60]])
+    _check_tensor(ds.data[[0, 1, -2, 5, -6, 10, 60]], data[[0, 1, -2, 5, -6, 10, 60]])
     _check_tensor(ds.data[0][[0, 1, 2, 5, 6, 10, 15]], data[0][[0, 1, 2, 5, 6, 10, 15]])
     _check_tensor(ds.data[[3, 2, 1, 0]][0], data[[3, 2, 1, 0]][0])
     _check_tensor(ds[[3, 2, 1, 0]][0].data, data[[3, 2, 1, 0]][0])
@@ -286,6 +291,8 @@ def test_compute_slices(memory_ds):
     _check_tensor(ds.data[:, :][0][(0, 1, 2), 0], data[:, :][0][(0, 1, 2), 0])
     _check_tensor(ds.data[0][(0, 1, 2), 0][1], data[0][(0, 1, 2), 0][1])
     _check_tensor(ds.data[:, :][0][(0, 1, 2), 0][1], data[:, :][0][(0, 1, 2), 0][1])
+    _check_tensor(ds.data[::-1], data[::-1])
+    _check_tensor(ds.data[::-3], data[::-3])
 
 
 def test_length_slices(memory_ds):

--- a/hub/core/index/index.py
+++ b/hub/core/index/index.py
@@ -83,7 +83,19 @@ def slice_at_int(s: slice, i: int):
 
     Returns:
         The index corresponding to the offset into the slice.
+
+    Raises:
+        NotImplementedError: Nontrivial slices should not be indexed with negative integers.
     """
+    if s == slice(None):
+        return i
+
+    if i < 0:
+        raise NotImplementedError(
+            "Subscripting slices with negative integers is not supported."
+        )
+    if s.step and s.step < 0:
+        return i * s.step - 1
     return (s.start or 0) + i * (s.step or 1)
 
 

--- a/hub/core/index/index.py
+++ b/hub/core/index/index.py
@@ -4,6 +4,17 @@ import numpy as np
 IndexValue = Union[int, slice, Tuple[int]]
 
 
+def has_negatives(s: slice) -> bool:
+    if s.start and s.start < 0:
+        return True
+    elif s.stop and s.stop < 0:
+        return True
+    elif s.step and s.step < 0:
+        return True
+    else:
+        return False
+
+
 def merge_slices(existing_slice: slice, new_slice: slice) -> slice:
     """Compose two slice objects
 
@@ -17,7 +28,20 @@ def merge_slices(existing_slice: slice, new_slice: slice) -> slice:
 
     Returns:
         slice: the composition of the given slices
+
+    Raises:
+        NotImplementedError: Composing slices with negative values is not supported.
+            Negative indexing for slices is only supported for the first slice.
     """
+    if existing_slice == slice(None):
+        return new_slice
+    elif new_slice == slice(None):
+        return existing_slice
+
+    if has_negatives(existing_slice) or has_negatives(new_slice):
+        raise NotImplementedError(
+            "Multiple subscripting for slices with negative values is not supported."
+        )
 
     # Combine the steps
     step1 = existing_slice.step if existing_slice.step is not None else 1
@@ -76,7 +100,7 @@ def slice_length(s: slice, parent_length: int) -> int:
 
 def tuple_length(t: Tuple[int], l: int) -> int:
     """Returns the length of a tuple of indexes given the length of its parent."""
-    return sum(1 for _ in filter(lambda i: i < l, t))
+    return len(t)
 
 
 class IndexEntry:
@@ -139,18 +163,14 @@ class IndexEntry:
 
     def indices(self, length: int):
         """Generates the sequence of integer indices for a target of a given length."""
+        parse_int = lambda i: i if i >= 0 else length + i
+
         if isinstance(self.value, int):
-            yield self.value
+            yield parse_int(self.value)
         elif isinstance(self.value, slice):
-            start = self.value.start or 0
-            stop = min(length, self.value.stop or length)
-            step = self.value.step or 1
-            yield from range(start, stop, step)
+            yield from range(*self.value.indices(length))
         elif isinstance(self.value, tuple):
-            for i in self.value:
-                if i >= length:
-                    break
-                yield i
+            yield from map(parse_int, self.value)
 
     def is_trivial(self):
         """Checks if an IndexEntry represents the entire slice"""

--- a/hub/core/index/tests/test_index.py
+++ b/hub/core/index/tests/test_index.py
@@ -24,6 +24,9 @@ class MergeSlicesCases:
     def case_irregular_steps(self):
         return slice(4, 101, 2), slice(10, 20, 3)
 
+    def case_negative_step(self):
+        return slice(None), slice(None, None, -3)
+
 
 @parametrize_with_cases("first,second", cases=MergeSlicesCases)
 def test_merge_slices(first: slice, second: slice):

--- a/hub/tests/common.py
+++ b/hub/tests/common.py
@@ -7,7 +7,7 @@ from hub.core.meta.index_meta import IndexMeta
 from hub.api.tensor import Tensor
 import os
 import pathlib
-from typing import Sequence, Tuple
+from typing import Sequence, Tuple, List
 from uuid import uuid1
 
 import numpy as np
@@ -135,3 +135,9 @@ def assert_all_samples_have_expected_compression(
             assert (
                 actual_compression == expected_compression
             ), f"non-uniform compression mismatch @ i={i}. got '{actual_compression}', expected '{expected_compression}'. If `tga`, check `NOTE` above this assertion."
+
+
+def assert_array_lists_equal(l1: List[np.ndarray], l2: List[np.ndarray]):
+    """Assert that two lists of numpy arrays are equal"""
+    for idx, (a1, a2) in enumerate(zip(l1, l2)):
+        np.testing.assert_array_equal(a1, a2, err_msg=f"Array mismatch at index {idx}")


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [x]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [x]  I have commented my code, particularly in hard-to-understand areas
- [x]  I have kept the `coverage-rate` up
- [ ]  I have performed a self-review of my own code and resolved any problems
- [x]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [x]  New and existing unit tests pass locally with my changes


### Changes

This PR adds support for simple negative slicing and indexing. The first level of slicing will always work:
```
# works
ds[-2:10:-3]
ds[5:-10:6]
ds[-100]
```
Multiple levels of slicing will work **only for positive slices**.
Slice composition at this level is not possible if we allow negatives, unless we use length information. The reason we don't do this is because the tensors are subject to change between indexing and access, and prematurely accessing length could lead to incorrect results.
```
# works
ds[2::3][::2]
ds[10:15:3][1:2]

# does not work
ds[::-3][::-3]
ds[-10::2][1:2]
ds[::3][-1] # negative integers after slices not allowed either
```

This PR also implements `assert_array_lists_equal`, which is used for testing equality of lists of numpy arrays, so we don't have to do a loop each time and so we can customize the error messaging.