### PR TITLE
client initiated only for hub datasets

### DIFF
--- a/hub/api/dataset.py
+++ b/hub/api/dataset.py
@@ -96,13 +96,14 @@ class Dataset:
 
         self.tensors: Dict[str, Tensor] = {}
 
-        self.client = HubBackendClient(token=token)
+        
         self._token = token
 
         if self.path.startswith("hub://"):
             split_path = self.path.split("/")
             self.org_id, self.ds_name = split_path[2], split_path[3]
-
+            self.client = HubBackendClient(token=token)
+            
         self.public = public
         self._load_meta()
 
@@ -363,6 +364,6 @@ class Dataset:
     @property
     def token(self):
         """Get attached token of the dataset"""
-        if self._token is None:
+        if self._token is None and self.path.startswith("hub://"):
             self._token = self.client.get_token()
         return self._token

--- a/hub/api/dataset.py
+++ b/hub/api/dataset.py
@@ -96,14 +96,13 @@ class Dataset:
 
         self.tensors: Dict[str, Tensor] = {}
 
-        
         self._token = token
 
         if self.path.startswith("hub://"):
             split_path = self.path.split("/")
             self.org_id, self.ds_name = split_path[2], split_path[3]
             self.client = HubBackendClient(token=token)
-            
+
         self.public = public
         self._load_meta()
 


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [x]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [x]  I have commented my code, particularly in hard-to-understand areas
- [x]  I have kept the `coverage-rate` up
- [x]  I have performed a self-review of my own code and resolved any problems
- [x]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [x]  I have described and made corresponding changes to the relevant documentation
- [x]  New and existing unit tests pass locally with my changes


### Changes

Local (or on-prem) datasets can be created without internet connection. 
