### PR TITLE
pytorch num_workers>0 for older python raises error

### DIFF
--- a/hub/integrations/tests/test_pytorch.py
+++ b/hub/integrations/tests/test_pytorch.py
@@ -1,3 +1,4 @@
+import sys
 from hub.util.remove_cache import get_base_storage
 import pytest
 from hub.util.exceptions import DatasetUnsupportedPytorch
@@ -24,6 +25,12 @@ def test_pytorch_small(ds):
         with pytest.raises(DatasetUnsupportedPytorch):
             dl = ds.pytorch(num_workers=2)
         return
+
+    if sys.version_info < (3, 8):
+        with pytest.raises(NotImplementedError):
+            dl = ds.pytorch(num_workers=2)
+        return
+
     dl = ds.pytorch(num_workers=2, batch_size=1)
 
     for i, batch in enumerate(dl):
@@ -88,6 +95,11 @@ def test_pytorch_transform(ds):
             dl = ds.pytorch(num_workers=2)
         return
 
+    if sys.version_info < (3, 8):
+        with pytest.raises(NotImplementedError):
+            dl = ds.pytorch(num_workers=2)
+        return
+
     dl = ds.pytorch(num_workers=2, transform=to_tuple, batch_size=1)
 
     for i, batch in enumerate(dl):
@@ -114,6 +126,12 @@ def test_pytorch_with_compression(ds: Dataset):
         with pytest.raises(DatasetUnsupportedPytorch):
             dl = ds.pytorch(num_workers=2)
         return
+
+    if sys.version_info < (3, 8):
+        with pytest.raises(NotImplementedError):
+            dl = ds.pytorch(num_workers=2)
+        return
+
     dl = ds.pytorch(num_workers=2, batch_size=1)
 
     for batch in dl:
@@ -155,6 +173,11 @@ def test_pytorch_small_old(ds):
 
 @requires_torch
 @parametrize_all_dataset_storages
+@pytest.mark.xfail(
+    sys.version_info < (3, 8),
+    raises=NotImplementedError,
+    reason="requires python3.8 or higher",
+)
 def test_custom_tensor_order(ds):
     with ds:
         tensors = ["a", "b", "c", "d"]
@@ -165,6 +188,11 @@ def test_custom_tensor_order(ds):
     if isinstance(get_base_storage(ds.storage), MemoryProvider):
         with pytest.raises(DatasetUnsupportedPytorch):
             ptds = ds.pytorch(num_workers=2)
+        return
+
+    if sys.version_info < (3, 8):
+        with pytest.raises(NotImplementedError):
+            dl = ds.pytorch(num_workers=2)
         return
 
     dl_new = ds.pytorch(num_workers=2, tensors=["c", "d", "a"])


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [x]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [x]  I have commented my code, particularly in hard-to-understand areas
- [x]  I have kept the `coverage-rate` up
- [x]  I have performed a self-review of my own code and resolved any problems
- [x]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [x]  I have described and made corresponding changes to the relevant documentation
- [x]  New and existing unit tests pass locally with my changes


### Changes

Old pytorch dataloader doesn't support multiple num_workers, currently it will raise an implement error to add support later.
