### PR TITLE
[small] Fix/2.0/readonly

### DIFF
--- a/hub/api/dataset.py
+++ b/hub/api/dataset.py
@@ -254,10 +254,6 @@ class Dataset:
             self.storage.disable_readonly()
         self._mode = new_mode
 
-    @property
-    def mode(self):
-        return self._mode
-
     @hub_reporter.record_call
     def pytorch(
         self,

--- a/hub/api/tests/test_readonly.py
+++ b/hub/api/tests/test_readonly.py
@@ -23,10 +23,10 @@ def test_readonly(local_ds):
 
     local_ds.create_tensor("tensor")
     local_ds.tensor.append(np.ones((100, 100)))
-    local_ds.mode = "r"
+    local_ds.read_only = True
     _assert_readonly_ops(local_ds, 1, (100, 100))
     del local_ds
 
     local_ds = Dataset(path)
-    local_ds.mode = "r"
+    local_ds.read_only = True
     _assert_readonly_ops(local_ds, 1, (100, 100))

--- a/hub/api/tests/test_readonly.py
+++ b/hub/api/tests/test_readonly.py
@@ -6,7 +6,7 @@ from hub import Dataset
 from hub.util.exceptions import ReadOnlyModeError
 
 
-def _assert_readonly_ops(ds: Dataset, num_samples: int, sample_shape: Tuple[int]):
+def _assert_readonly_ops(ds, num_samples: int, sample_shape: Tuple[int]):
     assert ds.mode == "r"
 
     with pytest.raises(ReadOnlyModeError):
@@ -18,7 +18,7 @@ def _assert_readonly_ops(ds: Dataset, num_samples: int, sample_shape: Tuple[int]
     assert ds.tensor.shape == (num_samples, *sample_shape)
 
 
-def test_readonly(local_ds: Dataset):
+def test_readonly(local_ds):
     path = local_ds.path
 
     local_ds.create_tensor("tensor")

--- a/hub/api/tests/test_readonly.py
+++ b/hub/api/tests/test_readonly.py
@@ -1,0 +1,32 @@
+from typing import Tuple
+import pytest
+import numpy as np
+
+from hub import Dataset
+from hub.util.exceptions import ReadOnlyModeError
+
+
+def _assert_readonly_ops(ds: Dataset, num_samples: int, sample_shape: Tuple[int]):
+    assert ds.mode == "r"
+
+    with pytest.raises(ReadOnlyModeError):
+        ds.tensor.append(np.ones(sample_shape))
+
+    assert len(ds) == num_samples
+    assert len(ds.tensor) == num_samples
+
+    assert ds.tensor.shape == (num_samples, *sample_shape)
+
+
+def test_readonly(local_ds: Dataset):
+    path = local_ds.path
+
+    local_ds.create_tensor("tensor")
+    local_ds.tensor.append(np.ones((100, 100)))
+    local_ds.mode = "r"
+    _assert_readonly_ops(local_ds, 1, (100, 100))
+    del local_ds
+
+    local_ds = Dataset(path)
+    local_ds.mode = "r"
+    _assert_readonly_ops(local_ds, 1, (100, 100))

--- a/hub/api/tests/test_readonly.py
+++ b/hub/api/tests/test_readonly.py
@@ -7,7 +7,7 @@ from hub.util.exceptions import ReadOnlyModeError
 
 
 def _assert_readonly_ops(ds, num_samples: int, sample_shape: Tuple[int]):
-    assert ds.mode == "r"
+    assert ds.read_only
 
     with pytest.raises(ReadOnlyModeError):
         ds.tensor.append(np.ones(sample_shape))

--- a/hub/core/chunk_engine.py
+++ b/hub/core/chunk_engine.py
@@ -188,6 +188,8 @@ class ChunkEngine:
             dtype (np.dtype): Data type for the sample that `buffer` represents.
         """
 
+        self.cache.check_readonly()
+
         # num samples is always 1 when appending
         num_samples = 1
 

--- a/hub/core/storage/lru_cache.py
+++ b/hub/core/storage/lru_cache.py
@@ -245,7 +245,7 @@ class LRUCache(StorageProvider):
         Raises:
             ReadOnlyError: If the provider is in read-only mode.
         """
-        self.check_readonly()
+
         self._free_up_space(len(value))
         self.cache_storage[path] = value  # type: ignore
         self.cache_used += len(value)


### PR DESCRIPTION
readonly method was failing when reading persistent data in readonly mode because LRU cache _insert_in_cache was calling check_readonly. i removed this check and added a test.