### PR TITLE
update sample compression API 

### DIFF
--- a/hub/api/dataset.py
+++ b/hub/api/dataset.py
@@ -157,7 +157,7 @@ class Dataset:
                 These defaults can be overridden by explicitly passing any of the other parameters to this function.
                 May also modify the defaults for other parameters.
             dtype (str): Optionally override this tensor's `dtype`. All subsequent samples are required to have this `dtype`.
-            sample_compression (str): Optionally override this tensor's `sample_compression`. Only used when the incoming data is uncompressed.
+            sample_compression (str): All samples will be compressed in the provided format. If `None`, samples are uncompressed.
             **kwargs: `htype` defaults can be overridden by passing any of the compatible parameters.
                 To see all `htype`s and their correspondent arguments, check out `hub/htypes.py`.
 

--- a/hub/api/dataset.py
+++ b/hub/api/dataset.py
@@ -1,5 +1,5 @@
 from hub.core.tensor import create_tensor
-from hub.constants import DEFAULT_HTYPE
+from hub.constants import DEFAULT_HTYPE, UNSPECIFIED
 from typing import Callable, Dict, Optional, Union, Tuple, List
 import numpy as np
 
@@ -144,9 +144,8 @@ class Dataset:
         name: str,
         htype: str = DEFAULT_HTYPE,
         chunk_size: int = None,
-        dtype: Union[str, np.dtype, type] = None,
-        sample_compression: str = None,
-        chunk_compression: str = None,
+        dtype: Union[str, np.dtype, type] = UNSPECIFIED,
+        sample_compression: str = UNSPECIFIED,
         **kwargs,
     ):
         """Creates a new tensor in the dataset.
@@ -163,7 +162,6 @@ class Dataset:
                 For more on chunking, check out `hub.core.chunk_engine.chunker`.
             dtype (str): Optionally override this tensor's `dtype`. All subsequent samples are required to have this `dtype`.
             sample_compression (str): Optionally override this tensor's `sample_compression`. Only used when the incoming data is uncompressed.
-            chunk_compression (str): Optionally override this tensor's `chunk_compression`. Currently not implemented.
             **kwargs: `htype` defaults can be overridden by passing any of the compatible parameters.
                 To see all `htype`s and their correspondent arguments, check out `hub/htypes.py`.
 
@@ -175,10 +173,6 @@ class Dataset:
             NotImplementedError: If trying to override `chunk_compression`.
         """
 
-        if chunk_compression is not None:
-            # TODO: implement chunk compression + update docstring
-            raise NotImplementedError("Chunk compression is not implemented yet!")
-
         if tensor_exists(name, self.storage):
             raise TensorAlreadyExistsError(name)
 
@@ -189,7 +183,6 @@ class Dataset:
             chunk_size=chunk_size,
             dtype=dtype,
             sample_compression=sample_compression,
-            chunk_compression=chunk_compression,
             **kwargs,
         )
         tensor = Tensor(name, self.storage)  # type: ignore

--- a/hub/api/tests/test_api.py
+++ b/hub/api/tests/test_api.py
@@ -9,7 +9,6 @@ from hub.tests.common import assert_array_lists_equal
 from hub.util.exceptions import (
     TensorDtypeMismatchError,
     TensorInvalidSampleShapeError,
-    TensorMetaMissingRequiredValue,
 )
 from hub.client.client import HubBackendClient
 from hub.client.utils import has_hub_testing_creds
@@ -385,7 +384,7 @@ def test_shape_property(memory_ds):
 
 
 def test_htype(memory_ds: Dataset):
-    image = memory_ds.create_tensor("image", htype="image")
+    image = memory_ds.create_tensor("image", htype="image", sample_compression="png")
     bbox = memory_ds.create_tensor("bbox", htype="bbox")
     label = memory_ds.create_tensor("label", htype="class_label")
     video = memory_ds.create_tensor("video", htype="video")
@@ -432,11 +431,6 @@ def test_dtype(memory_ds: Dataset):
     assert dtyped_tensor.dtype == np.uint8
     assert np_dtyped_tensor.dtype == MAX_FLOAT_DTYPE
     assert py_dtyped_tensor.dtype == MAX_FLOAT_DTYPE
-
-
-@pytest.mark.xfail(TensorMetaMissingRequiredValue, strict=True)
-def test_missing_sample_compression_for_image(memory_ds: Dataset):
-    memory_ds.create_tensor("tensor", htype="image")
 
 
 @pytest.mark.xfail(raises=TensorDtypeMismatchError, strict=True)

--- a/hub/api/tests/test_api_with_compression.py
+++ b/hub/api/tests/test_api_with_compression.py
@@ -1,4 +1,8 @@
-from hub.util.exceptions import SampleCompressionError, UnsupportedCompressionError
+from hub.util.exceptions import (
+    SampleCompressionError,
+    TensorMetaMissingRequiredValue,
+    UnsupportedCompressionError,
+)
 import pytest
 from hub.api.tensor import Tensor
 from hub.tests.common import TENSOR_KEY
@@ -35,7 +39,7 @@ def _populate_compressed_samples(tensor: Tensor, cat_path, flower_path, count=1)
 
 @parametrize_all_dataset_storages
 def test_populate_compressed_samples(ds: Dataset, cat_path, flower_path):
-    images = ds.create_tensor(TENSOR_KEY, htype="image")
+    images = ds.create_tensor(TENSOR_KEY, htype="image", sample_compression="png")
 
     assert images.meta.dtype == "uint8"
     assert images.meta.sample_compression == "png"
@@ -53,7 +57,7 @@ def test_populate_compressed_samples(ds: Dataset, cat_path, flower_path):
 
 @parametrize_all_dataset_storages
 def test_iterate_compressed_samples(ds: Dataset, cat_path, flower_path):
-    images = ds.create_tensor(TENSOR_KEY, htype="image")
+    images = ds.create_tensor(TENSOR_KEY, htype="image", sample_compression="png")
 
     assert images.meta.dtype == "uint8"
     assert images.meta.sample_compression == "png"
@@ -120,3 +124,8 @@ def test_jpeg_bad_shapes(memory_ds: Dataset, bad_shape):
 def test_unsupported_compression(memory_ds: Dataset):
     memory_ds.create_tensor(TENSOR_KEY, sample_compression="bad_compression")
     # TODO: same tests but with `dtype`
+
+
+@pytest.mark.xfail(raises=TensorMetaMissingRequiredValue, strict=True)
+def test_missing_sample_compression_for_image(memory_ds: Dataset):
+    memory_ds.create_tensor("tensor", htype="image")

--- a/hub/api/tests/test_api_with_compression.py
+++ b/hub/api/tests/test_api_with_compression.py
@@ -2,7 +2,6 @@ from hub.util.exceptions import SampleCompressionError, UnsupportedCompressionEr
 import pytest
 from hub.api.tensor import Tensor
 from hub.tests.common import TENSOR_KEY
-from hub.constants import UNCOMPRESSED
 import numpy as np
 
 import hub
@@ -40,9 +39,8 @@ def test_populate_compressed_samples(ds: Dataset, cat_path, flower_path):
 
     assert images.meta.dtype == "uint8"
     assert images.meta.sample_compression == "png"
-    assert images.meta.chunk_compression == UNCOMPRESSED
 
-    original_compressions = _populate_compressed_samples(images, cat_path, flower_path)
+    _populate_compressed_samples(images, cat_path, flower_path)
 
     assert images[0].numpy().shape == (900, 900, 3)
     assert images[1].numpy().shape == (513, 464, 4)
@@ -59,9 +57,8 @@ def test_iterate_compressed_samples(ds: Dataset, cat_path, flower_path):
 
     assert images.meta.dtype == "uint8"
     assert images.meta.sample_compression == "png"
-    assert images.meta.chunk_compression == UNCOMPRESSED
 
-    original_compressions = _populate_compressed_samples(images, cat_path, flower_path)
+    _populate_compressed_samples(images, cat_path, flower_path)
 
     expected_shapes = [
         (900, 900, 3),
@@ -83,7 +80,7 @@ def test_iterate_compressed_samples(ds: Dataset, cat_path, flower_path):
 
 @parametrize_all_dataset_storages
 def test_uncompressed(ds: Dataset):
-    images = ds.create_tensor(TENSOR_KEY, sample_compression=UNCOMPRESSED)
+    images = ds.create_tensor(TENSOR_KEY, sample_compression=None)
 
     images.append(np.ones((100, 100, 100)))
     images.extend(np.ones((3, 101, 2, 1)))

--- a/hub/constants.py
+++ b/hub/constants.py
@@ -12,10 +12,10 @@ DEFAULT_HTYPE = "generic"
 
 SUPPORTED_COMPRESSIONS = ["png", "jpeg", None]
 
-# used for htypes. if an htype uses this as the default, that means the user needs to specify themselves a value
-REQUIRE_USER_SPECIFICATION = "require_user"
+# used for requiring the user to specify a value for htype properties. notates that the htype property has no default.
+REQUIRE_USER_SPECIFICATION = "require_user_specification"
 
-# used instead of `None` for setting argument defaults. helpful for `REQUIRE_USER_SPECIFICATION` enforcement
+# used for `REQUIRE_USER_SPECIFICATION` enforcement. this should be used instead of `None` for default user method arguments.
 UNSPECIFIED = "unspecified"
 
 # If `True`  compression format has to be the same between samples in the same tensor.

--- a/hub/constants.py
+++ b/hub/constants.py
@@ -9,11 +9,14 @@ MB = 1000 * KB
 GB = 1000 * MB
 
 DEFAULT_HTYPE = "generic"
-UNCOMPRESSED = "uncompressed"
-DEFAULT_SAMPLE_COMPRESSION = UNCOMPRESSED
-DEFAULT_CHUNK_COMPRESSION = UNCOMPRESSED  # TODO: make lz4
 
-SUPPORTED_COMPRESSIONS = ["png", "jpeg", UNCOMPRESSED]
+SUPPORTED_COMPRESSIONS = ["png", "jpeg", None]
+
+# used for htypes. if an htype uses this as the default, that means the user needs to specify themselves a value
+REQUIRE_USER_SPECIFICATION = "require_user"
+
+# used instead of `None` for setting argument defaults. helpful for `REQUIRE_USER_SPECIFICATION` enforcement
+UNSPECIFIED = "unspecified"
 
 # If `True`  compression format has to be the same between samples in the same tensor.
 # If `False` compression format can   be different between samples in the same tensor.

--- a/hub/core/chunk_engine.py
+++ b/hub/core/chunk_engine.py
@@ -13,7 +13,7 @@ from hub.util.keys import (
     get_tensor_meta_key,
 )
 from hub.core.sample import Sample  # type: ignore
-from hub.constants import DEFAULT_MAX_CHUNK_SIZE, UNCOMPRESSED
+from hub.constants import DEFAULT_MAX_CHUNK_SIZE
 
 import numpy as np
 
@@ -275,7 +275,7 @@ class ChunkEngine:
 
         if isinstance(samples, np.ndarray):
             compression = self.tensor_meta.sample_compression
-            if compression == UNCOMPRESSED:
+            if compression is None:
                 buffers = []
 
                 # before adding any data, we need to check all sample sizes
@@ -369,7 +369,7 @@ class ChunkEngine:
     ) -> np.ndarray:
         """Read a sample from a chunk, converts the global index into a local index. Handles decompressing if applicable."""
 
-        expect_compressed = self.tensor_meta.sample_compression != UNCOMPRESSED
+        expect_compressed = self.tensor_meta.sample_compression is not None
         dtype = self.tensor_meta.dtype
 
         enc = self.chunk_id_encoder

--- a/hub/core/chunk_engine.py
+++ b/hub/core/chunk_engine.py
@@ -391,7 +391,7 @@ class ChunkEngine:
         if num_bytes > self.min_chunk_size:
             msg = f"Sorry, samples that exceed minimum chunk size ({self.min_chunk_size} bytes) are not supported yet (coming soon!). Got: {num_bytes} bytes."
 
-            if self.tensor_meta.sample_compression == UNCOMPRESSED:
+            if self.tensor_meta.sample_compression is None:
                 msg += "\nYour data is uncompressed, so setting `sample_compression` in `Dataset.create_tensor` could help here!"
 
             raise NotImplementedError(msg)

--- a/hub/core/compression.py
+++ b/hub/core/compression.py
@@ -1,4 +1,4 @@
-from hub.constants import SUPPORTED_COMPRESSIONS, UNCOMPRESSED
+from hub.constants import SUPPORTED_COMPRESSIONS
 from hub.util.exceptions import (
     SampleCompressionError,
     SampleDecompressionError,
@@ -41,7 +41,7 @@ def compress_array(array: np.ndarray, compression: str) -> bytes:
     if compression not in SUPPORTED_COMPRESSIONS:
         raise UnsupportedCompressionError(compression)
 
-    if compression == UNCOMPRESSED:
+    if compression is None:
         return array.tobytes()
 
     try:

--- a/hub/core/meta/tensor_meta.py
+++ b/hub/core/meta/tensor_meta.py
@@ -28,7 +28,7 @@ class TensorMeta(Meta):
 
     def __init__(
         self,
-        htype: str,
+        htype: str = UNSPECIFIED,
         **kwargs,
     ):
         """Tensor metadata is responsible for keeping track of global sample metadata within a tensor.
@@ -42,14 +42,16 @@ class TensorMeta(Meta):
             **kwargs: Any key that the provided `htype` has can be overridden via **kwargs. For more information, check out `hub.htypes`.
         """
 
-        _validate_htype(htype)
-        _validate_htype_overwrites(htype, kwargs)
-        _replace_unspecified_values(htype, kwargs)
-        _validate_required_htype_overwrites(kwargs)
+        if htype != UNSPECIFIED:
+            _validate_htype(htype)
+            _validate_htype_overwrites(htype, kwargs)
+            _replace_unspecified_values(htype, kwargs)
+            _validate_required_htype_overwrites(kwargs)
+            _format_values(kwargs)
 
-        required_meta = _required_meta_from_htype(htype)
-        required_meta.update(kwargs)
-        self.__dict__.update(required_meta)
+            required_meta = _required_meta_from_htype(htype)
+            required_meta.update(kwargs)
+            self.__dict__.update(required_meta)
 
         super().__init__()
 
@@ -108,7 +110,7 @@ class TensorMeta(Meta):
 
         if self.length <= 0:
             if self.dtype is None:
-                self.dtype = str(dtype)
+                self.dtype = dtype.name
 
             self.min_shape = list(shape)
             self.max_shape = list(shape)
@@ -188,6 +190,13 @@ def _validate_required_htype_overwrites(htype_overwrite: dict):
             lambda dtype: not _is_dtype_supported_by_numpy(dtype),
             "Datatype must be supported by numpy. Can be an `str`, `np.dtype`, or normal python type (like `bool`, `float`, `int`, etc.). List of available numpy dtypes found here: https://numpy.org/doc/stable/user/basics.types.html",
         )
+
+
+def _format_values(htype_overwrite: dict):
+    # TODO: docstring
+
+    if htype_overwrite["dtype"] is not None:
+        htype_overwrite["dtype"] = np.dtype(htype_overwrite["dtype"]).name
 
 
 def _validate_htype(htype: str):

--- a/hub/core/meta/tensor_meta.py
+++ b/hub/core/meta/tensor_meta.py
@@ -43,7 +43,7 @@ class TensorMeta(Meta):
         """
 
         if htype != UNSPECIFIED:
-            _validate_htype(htype)
+            _validate_htype_exists(htype)
             _validate_htype_overwrites(htype, kwargs)
             _replace_unspecified_values(htype, kwargs)
             _validate_required_htype_overwrites(kwargs)
@@ -134,7 +134,7 @@ class TensorMeta(Meta):
 
 
 def _required_meta_from_htype(htype: str) -> dict:
-    _validate_htype(htype)
+    _validate_htype_exists(htype)
     defaults = HTYPE_CONFIGURATIONS[htype]
 
     required_meta = {
@@ -149,9 +149,7 @@ def _required_meta_from_htype(htype: str) -> dict:
 
 
 def _validate_htype_overwrites(htype: str, htype_overwrite: dict):
-    """Raises appropriate errors if `htype_overwrite` keys/values are invalid in correspondence to `htype`. May modify `dtype` in `htype_overwrite` if it is a non-str."""
-
-    # TODO: update docstring
+    """Raises errors if `htype_overwrite` has invalid keys or was missing required values."""
 
     defaults = HTYPE_CONFIGURATIONS[htype]
 
@@ -168,7 +166,7 @@ def _validate_htype_overwrites(htype: str, htype_overwrite: dict):
 
 
 def _replace_unspecified_values(htype: str, htype_overwrite: dict):
-    # TODO: docstring
+    """Replaces `UNSPECIFIED` values in `htype_overwrite` with the `htype`'s defaults."""
 
     defaults = HTYPE_CONFIGURATIONS[htype]
 
@@ -178,7 +176,7 @@ def _replace_unspecified_values(htype: str, htype_overwrite: dict):
 
 
 def _validate_required_htype_overwrites(htype_overwrite: dict):
-    # TODO: docstring
+    """Raises errors if `htype_overwrite` has invalid values."""
 
     if htype_overwrite["sample_compression"] not in SUPPORTED_COMPRESSIONS:
         raise UnsupportedCompressionError(htype_overwrite["sample_compression"])
@@ -193,13 +191,13 @@ def _validate_required_htype_overwrites(htype_overwrite: dict):
 
 
 def _format_values(htype_overwrite: dict):
-    # TODO: docstring
+    """Replaces values in `htype_overwrite` with consistent types/formats."""
 
     if htype_overwrite["dtype"] is not None:
         htype_overwrite["dtype"] = np.dtype(htype_overwrite["dtype"]).name
 
 
-def _validate_htype(htype: str):
+def _validate_htype_exists(htype: str):
     if htype not in HTYPE_CONFIGURATIONS:
         raise TensorMetaInvalidHtype(htype, list(HTYPE_CONFIGURATIONS.keys()))
 

--- a/hub/core/meta/tensor_meta.py
+++ b/hub/core/meta/tensor_meta.py
@@ -134,6 +134,8 @@ class TensorMeta(Meta):
 
 
 def _required_meta_from_htype(htype: str) -> dict:
+    """Gets a dictionary with all required meta information to define a tensor."""
+
     _validate_htype_exists(htype)
     defaults = HTYPE_CONFIGURATIONS[htype]
 
@@ -153,10 +155,7 @@ def _validate_htype_overwrites(htype: str, htype_overwrite: dict):
 
     defaults = HTYPE_CONFIGURATIONS[htype]
 
-    # check that user specified all required values by the htype
     for key, value in htype_overwrite.items():
-
-        # check if user provided keys that don't exist for the `htype`
         if key not in defaults:
             raise TensorMetaInvalidHtypeOverwriteKey(htype, key, list(defaults.keys()))
 

--- a/hub/core/sample.py
+++ b/hub/core/sample.py
@@ -1,6 +1,5 @@
 # type: ignore
 from hub.core.compression import compress_array
-from hub.constants import UNCOMPRESSED
 import numpy as np
 import pathlib
 from typing import List, Optional, Tuple
@@ -41,7 +40,7 @@ class Sample:
         if array is not None:
             self.path = None
             self._array = array
-            self._original_compression = UNCOMPRESSED
+            self._original_compression = None
 
         self._compressed_bytes = None
         self._uncompressed_bytes = None
@@ -75,7 +74,7 @@ class Sample:
         self._read()
 
         if self.is_empty:
-            return UNCOMPRESSED
+            return None
 
         return self._original_compression.lower()
 
@@ -87,7 +86,7 @@ class Sample:
                 returned without re-compressing.
 
         Args:
-            compression (str): `self.array` will be compressed into this format. If `compression == UNCOMPRESSED`, return `self.uncompressed_bytes()`.
+            compression (str): `self.array` will be compressed into this format. If `compression is None`, return `self.uncompressed_bytes()`.
 
         Returns:
             bytes: Bytes for the compressed sample. Contains all metadata required to decompress within these bytes.
@@ -95,7 +94,7 @@ class Sample:
 
         compression = compression.lower()
 
-        if compression == UNCOMPRESSED:
+        if compression is None:
             return self.uncompressed_bytes()
 
         if self._compressed_bytes is None:

--- a/hub/core/tensor.py
+++ b/hub/core/tensor.py
@@ -20,8 +20,7 @@ def create_tensor(
         key (str): Key for where the chunks, index_meta, and tensor_meta will be located in `storage` relative to it's root.
         storage (StorageProvider): StorageProvider that all tensor data is written to.
         htype (str): Htype is how the default tensor metadata is defined.
-        sample_compression (str): If a sample is not already compressed (using `hub.load`), the sample will be compressed with `sample_compression`.
-            May be `None`, in which case samples are uncompressed before stored.
+        sample_compression (str): All samples will be compressed in the provided format. If `None`, samples are uncompressed.
         **kwargs: `htype` defaults can be overridden by passing any of the compatible parameters.
             To see all `htype`s and their correspondent arguments, check out `hub/htypes.py`.
 

--- a/hub/core/tensor.py
+++ b/hub/core/tensor.py
@@ -1,4 +1,3 @@
-from hub.constants import DEFAULT_HTYPE
 from hub.core.meta.tensor_meta import TensorMeta
 
 from hub.util.keys import get_tensor_meta_key, tensor_exists
@@ -11,9 +10,8 @@ from hub.util.exceptions import (
 def create_tensor(
     key: str,
     storage: StorageProvider,
-    htype: str = DEFAULT_HTYPE,
-    sample_compression: str = None,
-    chunk_compression: str = None,
+    htype: str,
+    sample_compression: str,
     **kwargs,
 ):
     """If a tensor does not exist, create a new one with the provided meta.
@@ -23,8 +21,7 @@ def create_tensor(
         storage (StorageProvider): StorageProvider that all tensor data is written to.
         htype (str): Htype is how the default tensor metadata is defined.
         sample_compression (str): If a sample is not already compressed (using `hub.load`), the sample will be compressed with `sample_compression`.
-            May be `UNCOMPRESSED`, in which case samples are uncompressed before stored.
-        chunk_compression (str): Chunk-wise compression has not been implemented yet. # TODO
+            May be `None`, in which case samples are uncompressed before stored.
         **kwargs: `htype` defaults can be overridden by passing any of the compatible parameters.
             To see all `htype`s and their correspondent arguments, check out `hub/htypes.py`.
 
@@ -39,7 +36,6 @@ def create_tensor(
     meta = TensorMeta(
         htype=htype,
         sample_compression=sample_compression,
-        chunk_compression=chunk_compression,
         **kwargs,
     )
     storage[meta_key] = meta  # type: ignore

--- a/hub/htypes.py
+++ b/hub/htypes.py
@@ -39,6 +39,7 @@ HTYPE_CONFIGURATIONS: Dict[str, Dict] = {
 # these configs are added to every `htype`
 COMMON_CONFIGS = {
     "sample_compression": None,
+    "dtype": None,
 }
 
 

--- a/hub/htypes.py
+++ b/hub/htypes.py
@@ -14,19 +14,16 @@ They are also used to inform default compression modes and data types.
 from re import L
 from typing import Dict
 from hub.constants import (
-    DEFAULT_CHUNK_COMPRESSION,
     DEFAULT_MAX_CHUNK_SIZE,
     DEFAULT_HTYPE,
-    DEFAULT_SAMPLE_COMPRESSION,
-    UNCOMPRESSED,
+    REQUIRE_USER_SPECIFICATION,
 )
 
 HTYPE_CONFIGURATIONS: Dict[str, Dict] = {
     DEFAULT_HTYPE: {"dtype": None},
     "image": {
         "dtype": "uint8",
-        "sample_compression": "png",
-        "chunk_compression": UNCOMPRESSED,
+        "sample_compression": REQUIRE_USER_SPECIFICATION,
     },
     "class_label": {
         "dtype": "uint32",
@@ -43,8 +40,7 @@ HTYPE_CONFIGURATIONS: Dict[str, Dict] = {
 # these configs are added to every `htype`
 COMMON_CONFIGS = {
     "chunk_size": DEFAULT_MAX_CHUNK_SIZE,
-    "chunk_compression": DEFAULT_CHUNK_COMPRESSION,
-    "sample_compression": DEFAULT_SAMPLE_COMPRESSION,
+    "sample_compression": None,
 }
 
 

--- a/hub/integrations/tests/test_pytorch.py
+++ b/hub/integrations/tests/test_pytorch.py
@@ -3,7 +3,6 @@ from hub.util.remove_cache import get_base_storage
 import pytest
 from hub.util.exceptions import DatasetUnsupportedPytorch
 from hub.core.storage.memory import MemoryProvider
-from hub.constants import UNCOMPRESSED
 from hub.api.dataset import Dataset
 import numpy as np
 
@@ -107,7 +106,7 @@ def test_pytorch_transform(ds):
 def test_pytorch_with_compression(ds: Dataset):
     # TODO: chunk-wise compression for labels (right now they are uncompressed)
     with ds:
-        images = ds.create_tensor("images", htype="image")
+        images = ds.create_tensor("images", htype="image", sample_compression=None)
         labels = ds.create_tensor("labels", htype="class_label")
 
         images.extend(np.ones((16, 100, 100, 3), dtype="uint8"))

--- a/hub/integrations/tests/test_pytorch.py
+++ b/hub/integrations/tests/test_pytorch.py
@@ -109,6 +109,8 @@ def test_pytorch_with_compression(ds: Dataset):
         images = ds.create_tensor("images", htype="image", sample_compression="png")
         labels = ds.create_tensor("labels", htype="class_label")
 
+        assert images.meta.sample_compression == "png"
+
         images.extend(np.ones((16, 100, 100, 3), dtype="uint8"))
         labels.extend(np.ones((16, 1), dtype="uint32"))
 

--- a/hub/integrations/tests/test_pytorch.py
+++ b/hub/integrations/tests/test_pytorch.py
@@ -106,7 +106,7 @@ def test_pytorch_transform(ds):
 def test_pytorch_with_compression(ds: Dataset):
     # TODO: chunk-wise compression for labels (right now they are uncompressed)
     with ds:
-        images = ds.create_tensor("images", htype="image", sample_compression=None)
+        images = ds.create_tensor("images", htype="image", sample_compression="png")
         labels = ds.create_tensor("labels", htype="class_label")
 
         images.extend(np.ones((16, 100, 100, 3), dtype="uint8"))

--- a/hub/integrations/tests/test_tensorflow.py
+++ b/hub/integrations/tests/test_tensorflow.py
@@ -1,4 +1,3 @@
-from hub.constants import UNCOMPRESSED
 from hub.api.dataset import Dataset
 import numpy as np
 
@@ -8,7 +7,7 @@ from hub.util.check_installation import requires_tensorflow
 @requires_tensorflow
 def test_tensorflow_with_compression(local_ds: Dataset):
     # TODO: when chunk-wise compression is done, `labels` should be compressed using lz4, so this test needs to be updated
-    images = local_ds.create_tensor("images", htype="image")
+    images = local_ds.create_tensor("images", htype="image", sample_compression=None)
     labels = local_ds.create_tensor("labels", htype="class_label")
 
     images.extend(np.ones((16, 100, 100, 3), dtype="uint8"))

--- a/hub/integrations/tests/test_tensorflow.py
+++ b/hub/integrations/tests/test_tensorflow.py
@@ -7,7 +7,7 @@ from hub.util.check_installation import requires_tensorflow
 @requires_tensorflow
 def test_tensorflow_with_compression(local_ds: Dataset):
     # TODO: when chunk-wise compression is done, `labels` should be compressed using lz4, so this test needs to be updated
-    images = local_ds.create_tensor("images", htype="image", sample_compression=None)
+    images = local_ds.create_tensor("images", htype="image", sample_compression="png")
     labels = local_ds.create_tensor("labels", htype="class_label")
 
     images.extend(np.ones((16, 100, 100, 3), dtype="uint8"))

--- a/hub/tests/common.py
+++ b/hub/tests/common.py
@@ -10,7 +10,7 @@ import numpy as np
 import posixpath
 import pytest
 
-from hub.constants import KB, MB, UNCOMPRESSED, USE_UNIFORM_COMPRESSION_PER_SAMPLE
+from hub.constants import KB, MB
 
 SESSION_ID = str(uuid1())
 
@@ -100,7 +100,7 @@ def get_actual_compression_from_buffer(buffer: memoryview) -> str:
 
     # TODO: better way of determining the sample has no compression
     except UnidentifiedImageError:
-        return UNCOMPRESSED
+        return None
 
 
 def assert_array_lists_equal(l1: List[np.ndarray], l2: List[np.ndarray]):

--- a/hub/tests/common.py
+++ b/hub/tests/common.py
@@ -3,7 +3,7 @@ from io import BytesIO
 from hub.api.tensor import Tensor
 import os
 import pathlib
-from typing import Sequence, Tuple, List
+from typing import Optional, Sequence, Tuple, List
 from uuid import uuid1
 
 import numpy as np
@@ -90,7 +90,7 @@ def test_get_random_array(shape: Tuple[int], dtype: str):
     assert array.dtype == dtype
 
 
-def get_actual_compression_from_buffer(buffer: memoryview) -> str:
+def get_actual_compression_from_buffer(buffer: memoryview) -> Optional[str]:
     """Helpful for checking if actual compression matches expected."""
 
     try:

--- a/hub/tests/common.py
+++ b/hub/tests/common.py
@@ -98,7 +98,6 @@ def get_actual_compression_from_buffer(buffer: memoryview) -> Optional[str]:
         img = Image.open(bio)
         return img.format.lower()
 
-    # TODO: better way of determining the sample has no compression
     except UnidentifiedImageError:
         return None
 

--- a/hub/util/exceptions.py
+++ b/hub/util/exceptions.py
@@ -315,6 +315,17 @@ class TensorMetaInvalidHtypeOverwriteValue(MetaError):
         )
 
 
+class TensorMetaMissingRequiredValue(MetaError):
+    def __init__(self, htype: str, key: str):
+        extra = ""
+        if key == "sample_compression":
+            extra = "`sample_compression` may be `None` if you want your '{htype}' data to be uncompressed."
+
+        super().__init__(
+            f"'{htype}' htype requires you to specify '{key}' inside the `create_tensor` method call. {extra}"
+        )
+
+
 class TensorMetaInvalidHtypeOverwriteKey(MetaError):
     def __init__(self, htype: str, key: str, available_keys: Sequence[str]):
         super().__init__(

--- a/hub/util/exceptions.py
+++ b/hub/util/exceptions.py
@@ -309,7 +309,7 @@ class TensorMetaInvalidHtype(MetaError):
 class TensorMetaInvalidHtypeOverwriteValue(MetaError):
     def __init__(self, key: str, value: Any, explanation: str = ""):
         super().__init__(
-            "Invalid value {} for tensor meta key {}. {}".format(
+            "Invalid value '{}' for tensor meta key {}. {}".format(
                 str(value), key, explanation
             )
         )

--- a/hub/util/exceptions.py
+++ b/hub/util/exceptions.py
@@ -319,10 +319,10 @@ class TensorMetaMissingRequiredValue(MetaError):
     def __init__(self, htype: str, key: str):
         extra = ""
         if key == "sample_compression":
-            extra = "`sample_compression` may be `None` if you want your '{htype}' data to be uncompressed."
+            extra = f"`sample_compression` may be `None` if you want your '{htype}' data to be uncompressed. Available compressors: {str(SUPPORTED_COMPRESSIONS)}"
 
         super().__init__(
-            f"'{htype}' htype requires you to specify '{key}' inside the `create_tensor` method call. {extra}"
+            f"Htype '{htype}' requires you to specify '{key}' inside the `create_tensor` method call. {extra}"
         )
 
 


### PR DESCRIPTION
before, `sample_compression=UNCOMPRESSED` was how you specify uncompressed tensors. instead, now it is: `sample_compression=None`.

also, if you are using an `image` `htype`, you are required to specify `sample_compression`, whether it be `None` or an actual compressor.

introduces a new `REQUIRE_USER_SPECIFICATION` constant that can be used by any htype property. if used, no default exists and the user must specify a value.

also removes all `chunk_compression` references for the time being.