### PR TITLE
Windows always uses old pytorch integration now

### DIFF
--- a/hub/integrations/__init__.py
+++ b/hub/integrations/__init__.py
@@ -1,7 +1,14 @@
+from hub.util.exceptions import WindowsSharedMemoryError
+
+
 try:
+    import os
+
+    if os.name == "nt":
+        raise WindowsSharedMemoryError
     from multiprocessing import shared_memory
     from .pytorch import dataset_to_pytorch
-except ImportError:
+except (ImportError, WindowsSharedMemoryError):
     from .pytorch_old import dataset_to_pytorch
 
 from .tensorflow import dataset_to_tensorflow

--- a/hub/integrations/pytorch_old.py
+++ b/hub/integrations/pytorch_old.py
@@ -8,6 +8,7 @@ from hub.util.exceptions import (
     TensorDoesNotExistError,
 )
 import hub
+import os
 
 
 def dataset_to_pytorch(
@@ -54,9 +55,14 @@ class TorchDataset:
     ):
 
         if python_version_warning:
-            warnings.warn(
-                "Python version<3.8 detected. Pytorch iteration speeds will be slow. Use newer Python versions for faster data streaming to Pytorch."
-            )
+            if os.name == "nt":
+                warnings.warn(
+                    "Windows OS detected. Pytorch iteration speeds will be slow. Use another OS along with Python version >= 3.8 for faster data streaming to Pytorch."
+                )
+            else:
+                warnings.warn(
+                    "Python version < 3.8 detected. Pytorch iteration speeds will be slow. Use newer Python versions for faster data streaming to Pytorch."
+                )
 
         self.dataset = None
 

--- a/hub/util/exceptions.py
+++ b/hub/util/exceptions.py
@@ -419,3 +419,10 @@ class ChunkSizeTooSmallError(ChunkEngineError):
         message="If the size of the last chunk is given, it must be smaller than the requested chunk size.",
     ):
         super().__init__(message)
+
+
+class WindowsSharedMemoryError(Exception):
+    def __init__(self):
+        super().__init__(
+            f"Python Shared memory with multiprocessing doesn't work properly on Windows."
+        )


### PR DESCRIPTION
A recent windows update seems to have broken Python shared memory + multiprocessing.
For now, Windows will always use the old pytorch integration.