### PR TITLE
Fixes dataset creation bug with s3/hub cloud datasets having similar names

### DIFF
--- a/hub/api/tests/test_api.py
+++ b/hub/api/tests/test_api.py
@@ -464,3 +464,10 @@ def test_hub_cloud_dataset():
         np.testing.assert_array_equal(ds.image[i].numpy(), i * np.ones((100, 100)))
 
     ds.delete()
+
+
+@parametrize_all_dataset_storages
+def test_hub_dataset_suffix_bug(ds):
+    # creating dataset with similar name but some suffix removed from end
+    ds2 = Dataset(ds.path[:-1])
+    ds2.delete()

--- a/hub/core/storage/s3.py
+++ b/hub/core/storage/s3.py
@@ -218,6 +218,8 @@ class S3Provider(StorageProvider):
         root = self.root.replace("s3://", "")
         self.bucket = root.split("/")[0]
         self.path = "/".join(root.split("/")[1:])
+        if not self.path.endswith("/"):
+            self.path += "/"
 
     def _set_hub_creds_info(self, tag: str, expiration: str):
         """Sets the tag and expiration of the credentials. These are only relevant to datasets using Hub storage.

--- a/hub/core/storage/s3.py
+++ b/hub/core/storage/s3.py
@@ -149,7 +149,7 @@ class S3Provider(StorageProvider):
             items = items["Contents"]
             names = [item["Key"] for item in items]
             # removing the prefix from the names
-            len_path = len(self.path.split("/"))
+            len_path = len(self.path.split("/")) - 1
             names = ["/".join(name.split("/")[len_path:]) for name in names]
             return names
         except Exception as err:


### PR DESCRIPTION
S3/hub cloud datasets with similar names was throwing errors during dataset creation.
This fixes it.

Earlier, the following blocks of code would have failed. They work now.
```python
ds1 = Dataset("hub://some_user/my_dataset_suffix")
ds2 = Dataset("hub://some_user/my_dataset")
```

```python
ds1 = Dataset("s3://some_bucket/my_dataset_suffix")
ds2 = Dataset("s3://some_bucket/my_dataset")
```