### PR TITLE
Fixes an issue in which reporting configuration file was not being created if its parent directory didn't exist.

### DIFF
--- a/hub/__init__.py
+++ b/hub/__init__.py
@@ -17,7 +17,7 @@ from .util.bugout_reporter import hub_reporter
 
 __all__ = ["Dataset", "Tensor", "load", "__version__"]
 
-__version__ = "2.0.0"
+__version__ = "2.0.1"
 __encoded_version__ = np.array(__version__)
 
 hub_reporter.tags.append(f"version:{__version__}")

--- a/hub/util/bugout_reporter.py
+++ b/hub/util/bugout_reporter.py
@@ -11,7 +11,7 @@ from humbug.report import HumbugReporter
 
 def save_reporting_config(
     consent: bool, client_id: Optional[str] = None, username: Optional[str] = None
-) -> None:
+) -> Dict[str, Any]:
     """Modify reporting config.
 
     Args:
@@ -51,22 +51,24 @@ def save_reporting_config(
     except Exception:
         pass
 
+    return reporting_config
+
 
 def get_reporting_config() -> Dict[str, Any]:
     """Get an existing reporting config"""
-    reporting_config = {}
-    repo_dir = os.getcwd()
-    if repo_dir is not None:
-        try:
-            if not os.path.exists(REPORTING_CONFIG_FILE_PATH):
-                client_id = str(uuid.uuid4())
-                reporting_config["client_id"] = client_id
-                save_reporting_config(True, client_id)
-            else:
-                with open(REPORTING_CONFIG_FILE_PATH, "r") as ifp:
-                    reporting_config = json.load(ifp)
-        except Exception:
-            pass
+    reporting_config = {"consent": False}
+    try:
+        if not os.path.exists(REPORTING_CONFIG_FILE_PATH):
+            client_id = str(uuid.uuid4())
+            reporting_config["client_id"] = client_id
+            reporting_config = save_reporting_config(True, client_id)
+        else:
+            with open(REPORTING_CONFIG_FILE_PATH, "r") as ifp:
+                reporting_config = json.load(ifp)
+    except Exception:
+        # Not being able to load reporting consent should not get in the user's way. We will just
+        # return the default reporting_config object in which consent is set to False.
+        pass
     return reporting_config
 
 

--- a/hub/util/bugout_reporter.py
+++ b/hub/util/bugout_reporter.py
@@ -18,6 +18,9 @@ def save_reporting_config(
         consent (bool): Enabling and disabling sending crashes and system report to Activeloop Hub.
         client_id (str, optional): Unique client id.
         username (str, optional): Activeloop username.
+
+    Returns:
+        The configuration that it just saved.
     """
     reporting_config = {}
 
@@ -56,7 +59,7 @@ def save_reporting_config(
 
 def get_reporting_config() -> Dict[str, Any]:
     """Get an existing reporting config"""
-    reporting_config = {"consent": False}
+    reporting_config: Dict[str, Any] = {"consent": False}
     try:
         if not os.path.exists(REPORTING_CONFIG_FILE_PATH):
             client_id = str(uuid.uuid4())


### PR DESCRIPTION
Now, we create the parent directory using `os.makedirs` in a manner similar to the `write_token` method in `hub/client/utils.py`.