### PR TITLE
Alternate fix for tensor creation bug

### DIFF
--- a/hub/api/dataset.py
+++ b/hub/api/dataset.py
@@ -182,7 +182,6 @@ class Dataset:
         if tensor_exists(name, self.storage):
             raise TensorAlreadyExistsError(name)
 
-        self.meta.tensors.append(name)
         create_tensor(
             name,
             self.storage,
@@ -191,6 +190,8 @@ class Dataset:
             sample_compression=sample_compression,
             **kwargs,
         )
+        self.meta.tensors.append(name)
+        self.storage.maybe_flush()
         tensor = Tensor(name, self.storage)  # type: ignore
 
         self.tensors[name] = tensor


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [x]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [x]  I have commented my code, particularly in hard-to-understand areas
- [x]  I have kept the `coverage-rate` up
- [x]  I have performed a self-review of my own code and resolved any problems
- [x]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [x]  I have described and made corresponding changes to the relevant documentation
- [x]  New and existing unit tests pass locally with my changes


### Changes

This is an alternate fix to the tensor creation bug encountered earlier. #1043 had fixed it partially, but in the old fix, if tensor creation failed due to an incorrect parameter such as wrong compression specified, the tensor would already be in the dataset's tensor list. Loading this dataset would then fail with a TensorDoesNotExistError as the actual tensor doesn't exist but the dataset's tensor list had it.
This PR rectifies the above issue.