### PR TITLE
Old pytorch multiprocessing bug fix

### DIFF
--- a/hub/integrations/pytorch/pytorch_old.py
+++ b/hub/integrations/pytorch/pytorch_old.py
@@ -1,3 +1,4 @@
+from hub.core.storage.s3 import S3Provider
 from hub.util.dataset import try_flushing
 from hub.core.storage.memory import MemoryProvider
 from hub.util.remove_cache import get_base_storage
@@ -11,6 +12,7 @@ from hub.util.exceptions import (
 )
 import hub
 import os
+import pickle
 
 from .common import convert_fn as default_convert_fn, collate_fn as default_collate_fn
 
@@ -76,14 +78,15 @@ class TorchDataset:
                 )
 
         self.dataset = None
-
-        self.storage = get_base_storage(dataset.storage)
-        self.index = dataset.index
-        if isinstance(self.storage, MemoryProvider):
+        storage = get_base_storage(dataset.storage)
+        self.pickled_storage = pickle.dumps(storage)
+        if isinstance(storage, MemoryProvider):
             raise DatasetUnsupportedPytorch(
                 "Datasets whose underlying storage is MemoryProvider are not supported for Pytorch iteration."
             )
 
+        self.index = dataset.index
+        self.length = len(dataset)
         self.transform = transform
         if tensors is None:
             self.tensor_keys = list(dataset.tensors)
@@ -101,11 +104,11 @@ class TorchDataset:
         For each process, dataset should be independently loaded
         """
         if self.dataset is None:
-            self.dataset = hub.Dataset(storage=self.storage, index=self.index)
+            storage = pickle.loads(self.pickled_storage)
+            self.dataset = hub.Dataset(storage=storage, index=self.index)
 
     def __len__(self):
-        self._init_ds()
-        return len(self.dataset)
+        return self.length
 
     def __getitem__(self, index: int):
         self._init_ds()


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [x]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [x]  I have commented my code, particularly in hard-to-understand areas
- [x]  I have kept the `coverage-rate` up
- [x]  I have performed a self-review of my own code and resolved any problems
- [x]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [x]  I have described and made corresponding changes to the relevant documentation
- [x]  New and existing unit tests pass locally with my changes


### Changes
The storage was getting reused across processes leading to s3 get issues in some cases. This fixes it and ensures each process uses a different storage.