### PR TITLE
[small] fix hub cloud throttling for tests

### DIFF
--- a/hub/api/tests/test_api.py
+++ b/hub/api/tests/test_api.py
@@ -21,7 +21,16 @@ MAX_INT_DTYPE = np.int_.__name__
 MAX_FLOAT_DTYPE = np.float_.__name__
 
 
-@enabled_persistent_dataset_generators
+# not using the predefined parametrizes because `hub_cloud_ds_generator` is not enabled by default
+@pytest.mark.parametrize(
+    "ds_generator",
+    [
+        "local_ds_generator",
+        "s3_ds_generator",
+        "hub_cloud_ds_generator",
+    ],
+    indirect=True,
+)
 def test_persist(ds_generator):
     ds = ds_generator()
 

--- a/hub/tests/dataset_fixtures.py
+++ b/hub/tests/dataset_fixtures.py
@@ -4,13 +4,13 @@ from hub import Dataset
 
 enabled_datasets = pytest.mark.parametrize(
     "ds",
-    ["memory_ds", "local_ds", "s3_ds", "hub_cloud_ds"],
+    ["memory_ds", "local_ds", "s3_ds"],
     indirect=True,
 )
 
 enabled_persistent_dataset_generators = pytest.mark.parametrize(
     "ds_generator",
-    ["local_ds_generator", "s3_ds_generator", "hub_cloud_ds_generator"],
+    ["local_ds_generator", "s3_ds_generator"],
     indirect=True,
 )
 

--- a/hub/tests/storage_fixtures.py
+++ b/hub/tests/storage_fixtures.py
@@ -7,13 +7,13 @@ import pytest
 
 enabled_storages = pytest.mark.parametrize(
     "storage",
-    ["memory_storage", "local_storage", "s3_storage", "hub_cloud_storage"],
+    ["memory_storage", "local_storage", "s3_storage"],
     indirect=True,
 )
 
 enabled_persistent_storages = pytest.mark.parametrize(
     "storage",
-    ["local_storage", "s3_storage", "hub_cloud_storage"],
+    ["local_storage", "s3_storage"],
     indirect=True,
 )
 


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [ ]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [ ]  I have performed a self-review of my own code and resolved any problems
- [ ]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [ ]  New and existing unit tests pass locally with my changes


### Changes

right now hub cloud is throttling us when multiple circleci runs are doing tests. this is because all tests are ran with hub cloud, when in reality we only need 1 or 2 tests since it's exactly the same as s3.