### PR TITLE
[small] Remove dataset link during creation of Hub datasets

### DIFF
--- a/hub/client/client.py
+++ b/hub/client/client.py
@@ -195,10 +195,7 @@ class HubBackendClient:
         )
 
         if response.status_code == 200:
-            logger.info(
-                "Your Hub dataset has been successfully created!"
-                + f"\nIt is available at {self.endpoint()}/datasets/explore?tag={tag}"
-            )
+            logger.info("Your Hub dataset has been successfully created!")
             if public is False:
                 logger.info("The dataset is private so make sure you are logged in!")
 


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [X]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [X]  I have performed a self-review of my own code and resolved any problems
- [X]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [X]  New and existing unit tests pass locally with my changes


### Changes

<!-- Describe your changes! Describe the scope of this PR's responsibilities. -->
This PR removes the link to the Dataset on https://app.activeloop.ai when a new Hub Dataset is created.