### PR TITLE
[small] implement `hub.like` in new api

### DIFF
--- a/hub/__init__.py
+++ b/hub/__init__.py
@@ -16,7 +16,8 @@ from .util.bugout_reporter import hub_reporter
 
 load = dataset.load
 empty = dataset.empty
-__all__ = ["dataset", "read", "__version__", "load", "empty"]
+like = dataset.like
+__all__ = ["dataset", "read", "__version__", "load", "empty", "like"]
 
 __version__ = "2.0.2"
 __encoded_version__ = np.array(__version__)

--- a/hub/api/dataset.py
+++ b/hub/api/dataset.py
@@ -1,6 +1,6 @@
 from hub.util.exceptions import DatasetHandlerError
 from hub.util.storage import get_storage_and_cache_chain
-from typing import Optional
+from typing import Optional, Union
 from hub.constants import DEFAULT_LOCAL_CACHE_SIZE, DEFAULT_MEMORY_CACHE_SIZE, MB
 from hub.core.dataset import Dataset
 from hub.util.keys import dataset_exists
@@ -187,15 +187,41 @@ class dataset:
 
     @staticmethod
     def like(
-        path: str, like: str, like_creds: dict, overwrite: bool = False
+        path: str,
+        source: Union[str, Dataset],
+        creds: dict = None,
+        overwrite: bool = False,
     ) -> Dataset:
-        """Creates a dataset with the same structure as another dataset"""
-        raise NotImplementedError
+        """Copies the `source` dataset's structure to a new location. No samples are copied, only the meta/info for the dataset and it's tensors.
+
+        Args:
+            path (str): Path where the new dataset will be created.
+            source (Union[str, Dataset]): Path or dataset object that will be used as the template for the new dataset.
+            creds (dict): Credentials that will be used to create the new dataset.
+            overwrite (bool): If True and a dataset exists at `destination`, it will be overwritten. Defaults to False.
+
+        Returns:
+            Dataset: New dataset object.
+        """
+
+        if overwrite:
+            # TODO:
+            raise NotImplementedError
+
+        destination_ds = dataset.empty(path, creds=creds)
+        source_ds = source
+        if isinstance(source, str):
+            source_ds = dataset.load(source)
+
+        for tensor_name, tensor in source_ds.tensors.items():
+            destination_ds.create_tensor_like(tensor_name, tensor)
+
+        destination_ds.info.update(source_ds.info.__getstate__())
+
+        return destination_ds
 
     @staticmethod
-    def ingest(
-        path: str, src: str, src_creds: dict, overwrite: bool = False
-    ) -> Dataset:
+    def ingest(path: str, source: str, creds: dict, overwrite: bool = False) -> Dataset:
         """Ingests a dataset from a source"""
         raise NotImplementedError
 

--- a/hub/api/dataset.py
+++ b/hub/api/dataset.py
@@ -213,8 +213,8 @@ class dataset:
         if isinstance(source, str):
             source_ds = dataset.load(source)
 
-        for tensor_name, tensor in source_ds.tensors.items():
-            destination_ds.create_tensor_like(tensor_name, tensor)
+        for tensor_name in source_ds.meta.tensors:
+            destination_ds.create_tensor_like(tensor_name, source_ds[tensor_name])
 
         destination_ds.info.update(source_ds.info.__getstate__())
 

--- a/hub/api/dataset.py
+++ b/hub/api/dataset.py
@@ -204,19 +204,15 @@ class dataset:
             Dataset: New dataset object.
         """
 
-        if overwrite:
-            # TODO:
-            raise NotImplementedError
-
-        destination_ds = dataset.empty(path, creds=creds)
+        destination_ds = dataset.empty(path, creds=creds, overwrite=overwrite)
         source_ds = source
         if isinstance(source, str):
             source_ds = dataset.load(source)
 
-        for tensor_name in source_ds.meta.tensors:
+        for tensor_name in source_ds.meta.tensors:  # type: ignore
             destination_ds.create_tensor_like(tensor_name, source_ds[tensor_name])
 
-        destination_ds.info.update(source_ds.info.__getstate__())
+        destination_ds.info.update(source_ds.info.__getstate__())  # type: ignore
 
         return destination_ds
 

--- a/hub/core/dataset.py
+++ b/hub/core/dataset.py
@@ -186,6 +186,33 @@ class Dataset:
 
         return tensor
 
+    @hub_reporter.record_call
+    def create_tensor_like(self, name: str, source: "Tensor") -> "Tensor":
+        """Copies the `source` tensor's meta information and creates a new tensor with it. No samples are copied, only the meta/info for the tensor is.
+
+        Args:
+            name (str): Name for the new tensor.
+            source (Tensor): Tensor who's meta/info will be copied. May or may not be contained in the same dataset.
+
+        Returns:
+            Tensor: New Tensor object.
+        """
+
+        info = source.info.__getstate__().copy()
+        meta = source.meta.__getstate__().copy()
+        del meta["min_shape"]
+        del meta["max_shape"]
+        del meta["length"]
+        del meta["version"]
+
+        destination_tensor = self.create_tensor(
+            name,
+            **meta,
+        )
+        destination_tensor.info.update(info)
+
+        return destination_tensor
+
     __getattr__ = __getitem__
 
     def __setattr__(self, name: str, value):

--- a/hub/core/meta/tensor_meta.py
+++ b/hub/core/meta/tensor_meta.py
@@ -188,6 +188,9 @@ class TensorMeta(Meta):
         # TODO: optimize this
         return len(self.tobytes())
 
+    def __str__(self):
+        return str(self.__getstate__())
+
 
 def _required_meta_from_htype(htype: str) -> dict:
     """Gets a dictionary with all required meta information to define a tensor."""


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [x]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [x]  I have commented my code, particularly in hard-to-understand areas
- [x]  I have kept the `coverage-rate` up
- [x]  I have performed a self-review of my own code and resolved any problems
- [x]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [x]  New and existing unit tests pass locally with my changes


### Changes

added: 

```python
import hub

hub.dataset.like(...)
hub.like(...)  # alias

# bonus:
ds1 = ...  # assume ds1 has a tensor named "images"
ds2 = ...


ds2.create_tensor_like(ds1.images)  # does the same thing as `hub.like(...)` but for a single tensor
```