### PR TITLE
Safe down casting for python scalars

### DIFF
--- a/hub/api/tests/test_api.py
+++ b/hub/api/tests/test_api.py
@@ -210,6 +210,24 @@ def test_empty_samples(ds: Dataset):
 
 
 @enabled_datasets
+def test_safe_downcasting(ds: Dataset):
+    tensor = ds.create_tensor("int", dtype="uint8")
+    tensor.append(0)
+    tensor.append(1)
+    tensor.extend([2, 3, 4])
+    tensor.extend([5, 6, np.uint8(7)])
+    with pytest.raises(TensorDtypeMismatchError):
+        tensor.append(-8)
+    tensor = ds.create_tensor("float", dtype="float32")
+    tensor.append(0)
+    tensor.append(1)
+    tensor.extend([2, 3.0, 4.0])
+    tensor.extend([5.0, 6.0, np.float32(7.0)])
+    with pytest.raises(TensorDtypeMismatchError):
+        tensor.append(float(np.finfo(np.float32).max + 1))
+
+
+@enabled_datasets
 def test_scalar_samples(ds: Dataset):
     tensor = ds.create_tensor("scalars")
 

--- a/hub/api/tests/test_api_with_compression.py
+++ b/hub/api/tests/test_api_with_compression.py
@@ -24,7 +24,9 @@ def _populate_compressed_samples(tensor: Tensor, cat_path, flower_path, count=1)
         original_compressions.append("png")
 
         tensor.append(np.ones((100, 100, 4), dtype="uint8"))
-        original_compressions.append(tensor.meta.sample_compression)
+        tensor.append(
+            np.ones((100, 100, 4), dtype=int).tolist()
+        )  # test safe downcasting of python scalars
 
         tensor.extend(
             [
@@ -32,9 +34,6 @@ def _populate_compressed_samples(tensor: Tensor, cat_path, flower_path, count=1)
                 hub.read(cat_path),
             ]
         )
-        original_compressions.extend(["png", "jpeg"])
-
-    return original_compressions
 
 
 @enabled_datasets
@@ -46,13 +45,25 @@ def test_populate_compressed_samples(ds: Dataset, cat_path, flower_path):
 
     _populate_compressed_samples(images, cat_path, flower_path)
 
-    assert images[0].numpy().shape == (900, 900, 3)
-    assert images[1].numpy().shape == (513, 464, 4)
+    expected_shapes = [
+        (900, 900, 3),
+        (513, 464, 4),
+        (100, 100, 4),
+        (100, 100, 4),
+        (513, 464, 4),
+        (900, 900, 3),
+    ]
 
-    assert len(images) == 5
-    assert images.shape == (5, None, None, None)
-    assert images.shape_interval.lower == (5, 100, 100, 3)
-    assert images.shape_interval.upper == (5, 900, 900, 4)
+    assert len(images) == 6
+
+    for img, exp_shape in zip(images, expected_shapes):
+        arr = img.numpy()
+        assert arr.shape == exp_shape
+        assert arr.dtype == "uint8"
+
+    assert images.shape == (6, None, None, None)
+    assert images.shape_interval.lower == (6, 100, 100, 3)
+    assert images.shape_interval.upper == (6, 900, 900, 4)
 
 
 @enabled_datasets
@@ -68,6 +79,7 @@ def test_iterate_compressed_samples(ds: Dataset, cat_path, flower_path):
         (900, 900, 3),
         (513, 464, 4),
         (100, 100, 4),
+        (100, 100, 4),
         (513, 464, 4),
         (900, 900, 3),
     ]
@@ -80,6 +92,7 @@ def test_iterate_compressed_samples(ds: Dataset, cat_path, flower_path):
             type(x) == np.ndarray
         ), "Check is necessary in case a `PIL` object is returned instead of an array."
         assert x.shape == expected_shape
+        assert x.dtype == "uint8"
 
 
 @enabled_datasets

--- a/hub/core/chunk_engine.py
+++ b/hub/core/chunk_engine.py
@@ -211,7 +211,9 @@ class ChunkEngine:
         num_samples = 1
 
         # update tensor meta first because erroneous meta information is better than un-accounted for data.
-        if not compressed:
+        if compressed:
+            self.tensor_meta.check_compatibility(shape, dtype)
+        else:
             buffer = self.tensor_meta.adapt(buffer, shape, dtype)
         self.tensor_meta.update(shape, dtype, num_samples)
 

--- a/hub/core/chunk_engine.py
+++ b/hub/core/chunk_engine.py
@@ -334,7 +334,7 @@ class ChunkEngine:
 
         elif isinstance(samples, Sequence):
             if is_uniform_sequence(samples):
-                self.extend(np.array(samples))
+                self.extend(np.array(samples, dtype=self.tensor_meta.dtype))
             else:
                 for sample in samples:
                     self.append(sample)
@@ -414,7 +414,7 @@ class ChunkEngine:
         if self.tensor_meta.sample_compression:
             sample = decompress_array(buffer, shape)
             if cast:
-                sample = self.tensor_meta.adapt(sample)
+                sample = np.cast[self.tensor_meta.dtype](sample)
         else:
             sample = np.frombuffer(buffer, dtype=dtype).reshape(shape)
 

--- a/hub/core/chunk_engine.py
+++ b/hub/core/chunk_engine.py
@@ -202,6 +202,7 @@ class ChunkEngine:
                 length of 0, in which case `shape` should contain at least one 0 (empty sample).
             shape (Tuple[int]): Shape for the sample that `buffer` represents.
             dtype (np.dtype): Data type for the sample that `buffer` represents.
+            compressed (bool): Whether buffer is compressed.
         """
 
         self.cache.check_readonly()

--- a/hub/core/meta/tensor_meta.py
+++ b/hub/core/meta/tensor_meta.py
@@ -78,16 +78,10 @@ class TensorMeta(Meta):
         """
         dtype = np.dtype(dtype)
         if self.dtype and self.dtype != dtype.name:
-            if np.can_cast(dtype, self.dtype):
-                buffer = memoryview(
-                    np.cast[self.dtype](np.frombuffer(buffer, dtype=dtype)).tobytes()
-                )
-            else:
-                raise TensorDtypeMismatchError(
-                    self.dtype,
-                    dtype.name,
-                    self.htype,
-                )
+            buffer = memoryview(  # Already verified this is safe in tensor.extend
+                np.cast[self.dtype](np.frombuffer(buffer, dtype=dtype)).tobytes()
+            )
+
         # shape length is only enforced after at least 1 sample exists.
         if self.length > 0:
             expected_shape_len = len(self.min_shape)

--- a/hub/core/meta/tensor_meta.py
+++ b/hub/core/meta/tensor_meta.py
@@ -94,13 +94,13 @@ class TensorMeta(Meta):
         # shape length is only enforced after at least 1 sample exists.
         if self.length > 0:
             expected_shape_len = len(self.min_shape)
-            actual_shape_len = len(shape)
+            actual_shape_len = len(shape)  # type: ignore
             if expected_shape_len != actual_shape_len:
                 raise TensorInvalidSampleShapeError(
                     "Sample shape length is expected to be {}, actual length is {}.".format(
                         expected_shape_len, actual_shape_len
                     ),
-                    shape,
+                    shape,  # type: ignore
                 )
         if isinstance(buffer, np.ndarray):
             return array

--- a/hub/core/tensor.py
+++ b/hub/core/tensor.py
@@ -110,6 +110,9 @@ class Tensor:
         Args:
             samples (np.ndarray, Sequence, Sequence[Sample]): The data to add to the tensor.
                 The length should be equal to the number of samples to add.
+
+        Raises:
+            TensorDtypeMismatchError: TensorDtypeMismatchError: Dtype for array must be equal to or castable to this tensor's dtype
         """
         if self.meta.dtype:
             err_dtype = get_incompatible_dtype(samples, self.meta.dtype)

--- a/hub/core/tensor.py
+++ b/hub/core/tensor.py
@@ -7,11 +7,13 @@ from hub.core.sample import Sample  # type: ignore
 from hub.core.chunk_engine import ChunkEngine, SampleValue
 from hub.api.info import load_info
 from hub.util.keys import get_tensor_meta_key, tensor_exists, get_tensor_info_key
+from hub.util.casting import get_incompatible_dtype
 from hub.util.shape import ShapeInterval
 from hub.util.exceptions import (
     TensorDoesNotExistError,
     InvalidKeyTypeError,
     TensorAlreadyExistsError,
+    TensorDtypeMismatchError,
 )
 
 
@@ -109,6 +111,14 @@ class Tensor:
             samples (np.ndarray, Sequence, Sequence[Sample]): The data to add to the tensor.
                 The length should be equal to the number of samples to add.
         """
+        if self.meta.dtype:
+            err_dtype = get_incompatible_dtype(samples, self.meta.dtype)
+            if err_dtype:
+                raise TensorDtypeMismatchError(
+                    self.meta.dtype,
+                    err_dtype,
+                    self.meta.htype,
+                )
         self.chunk_engine.extend(samples)
 
     def append(

--- a/hub/integrations/pytorch/pytorch.py
+++ b/hub/integrations/pytorch/pytorch.py
@@ -259,11 +259,16 @@ class TorchDataset:
         value = chunk_engine.read_sample_from_chunk(index, chunk, cast=False)
 
         # typecast if incompatible with pytorch
+        dtype = chunk_engine.tensor_meta.dtype
         if value.dtype == "uint16":
             value = value.astype("int32")
         elif value.dtype == "uint32" or value.dtype == "uint64":
             value = value.astype("int64")
-        return torch.tensor(value, dtype=chunk_engine.tensor_meta.dtype)  # type: ignore
+        if dtype == "uint16":
+            dtype = "int32"
+        elif dtype == "uin32" or dtype == "uint64":
+            dtype = "int64"
+        return torch.as_tensor(value, dtype=dtype)  # type: ignore
 
     def _get_data_from_chunks(
         self,

--- a/hub/integrations/pytorch/pytorch.py
+++ b/hub/integrations/pytorch/pytorch.py
@@ -256,7 +256,7 @@ class TorchDataset:
     def _numpy_from_chunk(self, index: int, key: str, chunk):
         """Takes a list of chunks and returns a numpy array from it"""
         chunk_engine = self.all_chunk_engines[key]
-        value = chunk_engine.read_sample_from_chunk(index, chunk)
+        value = chunk_engine.read_sample_from_chunk(index, chunk, cast=False)
 
         # typecast if incompatible with pytorch
         if value.dtype == "uint16":

--- a/hub/integrations/pytorch/pytorch.py
+++ b/hub/integrations/pytorch/pytorch.py
@@ -259,16 +259,13 @@ class TorchDataset:
         value = chunk_engine.read_sample_from_chunk(index, chunk, cast=False)
 
         # typecast if incompatible with pytorch
-        dtype = chunk_engine.tensor_meta.dtype
-        if value.dtype == "uint16":
-            value = value.astype("int32")
-        elif value.dtype == "uint32" or value.dtype == "uint64":
-            value = value.astype("int64")
-        if dtype == "uint16":
-            dtype = "int32"
-        elif dtype == "uin32" or dtype == "uint64":
-            dtype = "int64"
-        return torch.as_tensor(value, dtype=dtype)  # type: ignore
+        tensor_dtype = chunk_engine.tensor_meta.dtype
+        casts = {"uint16": "int32", "uint32": "int64", "uint64": "int64"}
+        to_dtype = casts.get(value.dtype.name)
+        if to_dtype:
+            value = value.astype(to_dtype)
+        tensor_dtype = casts.get(tensor_dtype, tensor_dtype)
+        return torch.as_tensor(value, dtype=tensor_dtype)  # type: ignore
 
     def _get_data_from_chunks(
         self,

--- a/hub/integrations/pytorch/pytorch.py
+++ b/hub/integrations/pytorch/pytorch.py
@@ -263,7 +263,7 @@ class TorchDataset:
             value = value.astype("int32")
         elif value.dtype == "uint32" or value.dtype == "uint64":
             value = value.astype("int64")
-        return torch.tensor(value)  # type: ignore
+        return torch.tensor(value, dtype=chunk_engine.tensor_meta.dtype)  # type: ignore
 
     def _get_data_from_chunks(
         self,

--- a/hub/util/casting.py
+++ b/hub/util/casting.py
@@ -14,7 +14,7 @@ def get_incompatible_dtype(
         None if all samples are compatible. If not, the dtype of the offending item is returned.
 
     Raises:
-        TypeError if samples is of unexepcted type.
+        TypeError: if samples is of unexepcted type.
     """
     if isinstance(samples, (int, float, bool, str)) or hasattr(samples, "dtype"):
         return (

--- a/hub/util/casting.py
+++ b/hub/util/casting.py
@@ -1,0 +1,19 @@
+from typing import Union, Sequence
+import numpy as np
+
+
+def get_incompatible_dtype(
+    item: Union[np.ndarray, Sequence], dtype: Union[str, np.dtype]
+):
+    if isinstance(item, (int, float, bool, str)) or hasattr(item, "dtype"):
+        return (
+            False
+            if np.can_cast(item, dtype)
+            else getattr(item, "dtype", np.array(item).dtype)
+        )
+    elif isinstance(item, Sequence):
+        return all(map(lambda x: get_incompatible_dtype(x, dtype), item))
+    else:
+        raise TypeError(
+            f"Unexpected object {item}. Expected np.ndarray, int, float, bool, str or Sequence."
+        )

--- a/hub/util/casting.py
+++ b/hub/util/casting.py
@@ -19,7 +19,7 @@ def get_incompatible_dtype(
     if isinstance(samples, (int, float, bool, str)) or hasattr(samples, "dtype"):
         return (
             None
-            if np.can_cast(samples, dtype)
+            if np.can_cast(getattr(samples, "dtype", samples), dtype)
             else getattr(samples, "dtype", np.array(samples).dtype)
         )
     elif isinstance(samples, Sequence):

--- a/hub/util/casting.py
+++ b/hub/util/casting.py
@@ -6,7 +6,7 @@ def get_incompatible_dtype(
     samples: Union[np.ndarray, Sequence], dtype: Union[str, np.dtype]
 ):
     """Check if items in a non-uniform mixed dtype sequence of samples can be safely cast to the given dtype.
-    
+
     Args:
         samples: Sequence of samples
         dtype: dtype to which samples have to be cast

--- a/hub/util/casting.py
+++ b/hub/util/casting.py
@@ -3,17 +3,28 @@ import numpy as np
 
 
 def get_incompatible_dtype(
-    item: Union[np.ndarray, Sequence], dtype: Union[str, np.dtype]
+    samples: Union[np.ndarray, Sequence], dtype: Union[str, np.dtype]
 ):
-    if isinstance(item, (int, float, bool, str)) or hasattr(item, "dtype"):
+    """Check if items in a non-uniform mixed dtype sequence of samples can be safely cast to the given dtype.
+    Args:
+        samples: Sequence of samples
+        dtype: dtype to which samples have to be cast
+
+    Returns:
+        None if all samples are compatible. If not, the dtype of the offending item is returned.
+
+    Raises:
+        TypeError if samples is of unexepcted type.
+    """
+    if isinstance(samples, (int, float, bool, str)) or hasattr(samples, "dtype"):
         return (
-            False
-            if np.can_cast(item, dtype)
-            else getattr(item, "dtype", np.array(item).dtype)
+            None
+            if np.can_cast(samples, dtype)
+            else getattr(samples, "dtype", np.array(samples).dtype)
         )
-    elif isinstance(item, Sequence):
-        return all(map(lambda x: get_incompatible_dtype(x, dtype), item))
+    elif isinstance(samples, Sequence):
+        return all(map(lambda x: get_incompatible_dtype(x, dtype), samples))
     else:
         raise TypeError(
-            f"Unexpected object {item}. Expected np.ndarray, int, float, bool, str or Sequence."
+            f"Unexpected object {samples}. Expected np.ndarray, int, float, bool, str or Sequence."
         )

--- a/hub/util/casting.py
+++ b/hub/util/casting.py
@@ -24,7 +24,11 @@ def get_incompatible_dtype(
             else getattr(samples, "dtype", np.array(samples).dtype)
         )
     elif isinstance(samples, Sequence):
-        return all(map(lambda x: get_incompatible_dtype(x, dtype), samples))
+        for x in samples:
+            err_dtype = get_incompatible_dtype(x, dtype)
+            if err_dtype:
+                return err_dtype
+        return None
     else:
         raise TypeError(
             f"Unexpected object {samples}. Expected np.ndarray, int, float, bool, str or Sequence."


### PR DESCRIPTION
## 🚀 🚀 Pull Request


https://activeloop.atlassian.net/browse/AL-1219


### Checklist:

- [x]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [x]  I have commented my code, particularly in hard-to-understand areas
- [x]  I have kept the `coverage-rate` up
- [x]  I have performed a self-review of my own code and resolved any problems
- [x]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [x]  I have described and made corresponding changes to the relevant documentation
- [x]  New and existing unit tests pass locally with my changes


### Changes

* Safe downcasting for python scalars:
```python
import hub
ds = hub.dataset("mem://test")
labels = ds.create_tensor("labels", dtype="uint8")

labels.append(0)  # Works

labels.append(-1)  # Fails

```