### PR TITLE
Remove default logging code in client

### DIFF
--- a/hub/client/log.py
+++ b/hub/client/log.py
@@ -8,11 +8,3 @@ import logging
 import sys
 
 logger = logging.getLogger("hub")
-
-
-def configure_logger(debug=0):
-    log_level = logging.DEBUG if debug == 1 else logging.INFO
-    logging.basicConfig(format="%(message)s", level=log_level, stream=sys.stdout)
-
-
-configure_logger(0)


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [x]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [x]  I have commented my code, particularly in hard-to-understand areas
- [x]  I have kept the `coverage-rate` up
- [x]  I have performed a self-review of my own code and resolved any problems
- [x]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [x]  I have described and made corresponding changes to the relevant documentation
- [x]  New and existing unit tests pass locally with my changes


### Changes

Removes the default initialization of the logging configuration in the client. This sets the default to the default, so it should be harmless to remove.

Make sure to validate the CI output before merging.