### PR TITLE
Ban dataset attributes as tensor names

### DIFF
--- a/hub/api/tests/test_api.py
+++ b/hub/api/tests/test_api.py
@@ -9,6 +9,7 @@ from hub.util.exceptions import (
     TensorInvalidSampleShapeError,
     DatasetHandlerError,
     UnsupportedCompressionError,
+    InvalidTensorNameError,
 )
 from hub.constants import MB
 
@@ -647,3 +648,12 @@ def test_dataset_delete():
         assert not os.path.isfile("test/dataset_meta.json")
 
         hub.constants.DELETE_SAFETY_SIZE = old_size
+
+
+def test_invalid_tesnor_name(memory_ds):
+    with pytest.raises(InvalidTensorNameError):
+        memory_ds.create_tensor("meta")
+    with pytest.raises(InvalidTensorNameError):
+        memory_ds.create_tensor("tensors")
+    with pytest.raises(InvalidTensorNameError):
+        memory_ds.create_tensor("info")

--- a/hub/core/dataset.py
+++ b/hub/core/dataset.py
@@ -25,6 +25,7 @@ from hub.util.exceptions import (
     ReadOnlyModeError,
     TensorAlreadyExistsError,
     TensorDoesNotExistError,
+    InvalidTensorNameError,
 )
 from hub.client.client import HubBackendClient
 from hub.client.log import logger
@@ -176,6 +177,8 @@ class Dataset:
 
         if tensor_exists(name, self.storage):
             raise TensorAlreadyExistsError(name)
+        if name in vars(self).keys():
+            raise InvalidTensorNameError(name)
 
         # Seperate meta and info
 

--- a/hub/core/dataset.py
+++ b/hub/core/dataset.py
@@ -172,6 +172,7 @@ class Dataset:
 
         Raises:
             TensorAlreadyExistsError: Duplicate tensors are not allowed.
+            InvalidTensorNameError: If `name` is in dataset attributes.
             NotImplementedError: If trying to override `chunk_compression`.
         """
 

--- a/hub/core/dataset.py
+++ b/hub/core/dataset.py
@@ -178,7 +178,7 @@ class Dataset:
 
         if tensor_exists(name, self.storage):
             raise TensorAlreadyExistsError(name)
-        if name in vars(self).keys():
+        if name in vars(self):
             raise InvalidTensorNameError(name)
 
         # Seperate meta and info

--- a/hub/util/exceptions.py
+++ b/hub/util/exceptions.py
@@ -64,6 +64,13 @@ class TensorAlreadyExistsError(Exception):
         super().__init__(f"Tensor '{key}' already exists.")
 
 
+class InvalidTensorNameError(Exception):
+    def __init__(self, name: str):
+        super().__init__(
+            f"The use of a reserved attribute '{name}' as a tensor name is invalid."
+        )
+
+
 class DynamicTensorNumpyError(Exception):
     def __init__(self, key: str, index, property_key: str):
         super().__init__(


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [x]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [x]  I have commented my code, particularly in hard-to-understand areas
- [x]  I have kept the `coverage-rate` up
- [x]  I have performed a self-review of my own code and resolved any problems
- [x]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [x]  I have described and made corresponding changes to the relevant documentation
- [x]  New and existing unit tests pass locally with my changes


### Changes

Add check for reserved names in .create_tensor().