### PR TITLE
[small] `hub.htypes` is a list of all htypes

### DIFF
--- a/hub/__init__.py
+++ b/hub/__init__.py
@@ -14,7 +14,9 @@ from .api.dataset import dataset
 from .api.read import read
 from .core.transform import compute, compose
 from .util.bugout_reporter import hub_reporter
+from .htype import HTYPE_CONFIGURATIONS
 
+htypes = list(HTYPE_CONFIGURATIONS.keys())
 list = dataset.list
 load = dataset.load
 empty = dataset.empty
@@ -33,6 +35,7 @@ __all__ = [
     "like",
     "ingest",
     "ingest_kaggle",
+    "htypes",
 ]
 
 __version__ = "2.0.4"

--- a/hub/api/tests/test_api.py
+++ b/hub/api/tests/test_api.py
@@ -657,3 +657,15 @@ def test_invalid_tesnor_name(memory_ds):
         memory_ds.create_tensor("tensors")
     with pytest.raises(InvalidTensorNameError):
         memory_ds.create_tensor("info")
+
+
+def test_htypes_list():
+    assert hub.htypes == [
+        "generic",
+        "image",
+        "class_label",
+        "bbox",
+        "video",
+        "binary_mask",
+        "segment_mask",
+    ]

--- a/hub/client/client.py
+++ b/hub/client/client.py
@@ -1,5 +1,6 @@
+import hub
 import requests
-from typing import Dict, Optional
+from typing import Optional
 from hub.util.exceptions import LoginException, InvalidPasswordException
 from hub.client.utils import check_response_status, write_token, read_token
 from hub.client.config import (
@@ -12,12 +13,10 @@ from hub.client.config import (
     GET_DATASET_CREDENTIALS_SUFFIX,
     CREATE_DATASET_SUFFIX,
     DATASET_SUFFIX,
-    UPDATE_SUFFIX,
     LIST_DATASETS,
     GET_USER_PROFILE,
 )
 from hub.client.log import logger
-import hub
 
 
 class HubBackendClient:

--- a/hub/constants.py
+++ b/hub/constants.py
@@ -9,8 +9,6 @@ KB = 1000 * B
 MB = 1000 * KB
 GB = 1000 * MB
 
-DEFAULT_HTYPE = "generic"
-
 SUPPORTED_COMPRESSIONS = [
     "bmp",
     "dib",
@@ -40,11 +38,6 @@ SUPPORTED_COMPRESSIONS.append(None)  # type: ignore
 
 COMPRESSION_ALIASES = {"jpg": "jpeg"}
 
-# used for requiring the user to specify a value for htype properties. notates that the htype property has no default.
-REQUIRE_USER_SPECIFICATION = "require_user_specification"
-
-# used for `REQUIRE_USER_SPECIFICATION` enforcement. this should be used instead of `None` for default user method arguments.
-UNSPECIFIED = "unspecified"
 
 # If `True`  compression format has to be the same between samples in the same tensor.
 # If `False` compression format can   be different between samples in the same tensor.

--- a/hub/core/dataset.py
+++ b/hub/core/dataset.py
@@ -3,8 +3,7 @@ from hub.api.info import load_info
 from hub.core.storage.provider import StorageProvider
 from hub.core.tensor import create_tensor, Tensor
 from typing import Any, Callable, Dict, Optional, Union, Tuple, List, Sequence
-from hub.constants import DEFAULT_HTYPE, UNSPECIFIED
-from hub.htypes import HTYPE_CONFIGURATIONS
+from hub.htype import HTYPE_CONFIGURATIONS, DEFAULT_HTYPE, UNSPECIFIED
 import numpy as np
 
 from hub.core.meta.dataset_meta import DatasetMeta

--- a/hub/core/meta/tensor_meta.py
+++ b/hub/core/meta/tensor_meta.py
@@ -9,12 +9,10 @@ from hub.util.exceptions import (
     TensorInvalidSampleShapeError,
 )
 from hub.constants import (
-    REQUIRE_USER_SPECIFICATION,
     SUPPORTED_COMPRESSIONS,
     COMPRESSION_ALIASES,
-    UNSPECIFIED,
 )
-from hub.htypes import HTYPE_CONFIGURATIONS
+from hub.htype import HTYPE_CONFIGURATIONS, REQUIRE_USER_SPECIFICATION, UNSPECIFIED
 from hub.core.meta.meta import Meta
 
 
@@ -39,7 +37,7 @@ class TensorMeta(Meta):
 
         Args:
             htype (str): All tensors require an `htype`. This determines the default meta keys/values.
-            **kwargs: Any key that the provided `htype` has can be overridden via **kwargs. For more information, check out `hub.htypes`.
+            **kwargs: Any key that the provided `htype` has can be overridden via **kwargs. For more information, check out `hub.htype`.
         """
 
         if htype != UNSPECIFIED:

--- a/hub/htype.py
+++ b/hub/htype.py
@@ -29,12 +29,16 @@ Supported htypes and their respective defaults are:
 
 """
 
-from re import L
 from typing import Dict
-from hub.constants import (
-    DEFAULT_HTYPE,
-    REQUIRE_USER_SPECIFICATION,
-)
+
+DEFAULT_HTYPE = "generic"
+
+# used for requiring the user to specify a value for htype properties. notates that the htype property has no default.
+REQUIRE_USER_SPECIFICATION = "require_user_specification"
+
+# used for `REQUIRE_USER_SPECIFICATION` enforcement. this should be used instead of `None` for default user method arguments.
+UNSPECIFIED = "unspecified"
+
 
 HTYPE_CONFIGURATIONS: Dict[str, Dict] = {
     DEFAULT_HTYPE: {"dtype": None},

--- a/hub/util/exceptions.py
+++ b/hub/util/exceptions.py
@@ -1,4 +1,4 @@
-from hub.htypes import HTYPE_CONFIGURATIONS
+from hub.htype import HTYPE_CONFIGURATIONS
 from hub.constants import SUPPORTED_COMPRESSIONS
 from typing import Any, List, Sequence, Tuple
 


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [ ]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [ ]  I have performed a self-review of my own code and resolved any problems
- [ ]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [ ]  New and existing unit tests pass locally with my changes


### Changes

renames `hub/htypes.py` -> `hub/htype.py`

```python
import hub

hub.htypes  # returns a list of all available htypes
``` 

just a cleaner api