### PR TITLE
Faster chunk serialization

### DIFF
--- a/hub/core/serialize.py
+++ b/hub/core/serialize.py
@@ -65,26 +65,21 @@ def serialize_chunk(
 
     # Write shape info
     if shape_info.ndim == 1:
-        flatbuff[offset : offset + 8] = np.zeros(8, dtype=np.byte).tobytes()
         offset += 8
     else:
-        flatbuff[offset : offset + 8] = np.array(
-            shape_info.shape, dtype=np.int32
-        ).tobytes()
+        flatbuff[offset : offset + 4] = shape_info.shape[0].to_bytes(4, "little")
+        flatbuff[offset + 4 : offset + 8] = shape_info.shape[1].to_bytes(4, "little")
         offset += 8
-        flatbuff[offset : offset + shape_info.nbytes] = shape_info.reshape(-1).tobytes()
+        flatbuff[offset : offset + shape_info.nbytes] = shape_info.tobytes()
         offset += shape_info.nbytes
 
     # Write byte positions
     if byte_positions.ndim == 1:
-        flatbuff[offset : offset + 4] = np.zeros(4, dtype=np.byte).tobytes()
         offset += 4
     else:
-        flatbuff[offset : offset + 4] = np.int32(byte_positions.shape[0]).tobytes()
+        flatbuff[offset : offset + 4] = byte_positions.shape[0].to_bytes(4, "little")
         offset += 4
-        flatbuff[offset : offset + byte_positions.nbytes] = byte_positions.reshape(
-            -1
-        ).tobytes()
+        flatbuff[offset : offset + byte_positions.nbytes] = byte_positions.tobytes()
         offset += byte_positions.nbytes
 
     # Write actual data

--- a/hub/core/serialize.py
+++ b/hub/core/serialize.py
@@ -55,7 +55,7 @@ def serialize_chunk(
         Serialized chunk as memoryview.
     """
     nbytes = infer_chunk_num_bytes(version, shape_info, byte_positions, data, len_data)
-    flatbuff = np.zeros(nbytes, dtype=np.byte)
+    flatbuff = bytearray(nbytes)
 
     # Write version
     len_version = len(version)
@@ -65,38 +65,34 @@ def serialize_chunk(
 
     # Write shape info
     if shape_info.ndim == 1:
-        flatbuff[offset : offset + 8] = np.zeros(8, dtype=np.byte)
+        flatbuff[offset : offset + 8] = np.zeros(8, dtype=np.byte).tobytes()
         offset += 8
     else:
-        flatbuff[offset : offset + 8] = np.array(shape_info.shape, dtype=np.int32).view(
-            np.byte
-        )
+        flatbuff[offset : offset + 8] = np.array(
+            shape_info.shape, dtype=np.int32
+        ).tobytes()
         offset += 8
-        flatbuff[offset : offset + shape_info.nbytes] = shape_info.reshape(-1).view(
-            np.byte
-        )
+        flatbuff[offset : offset + shape_info.nbytes] = shape_info.reshape(-1).tobytes()
         offset += shape_info.nbytes
 
     # Write byte positions
     if byte_positions.ndim == 1:
-        flatbuff[offset : offset + 4] = np.zeros(4, dtype=np.byte)
+        flatbuff[offset : offset + 4] = np.zeros(4, dtype=np.byte).tobytes()
         offset += 4
     else:
-        flatbuff[offset : offset + 4] = np.int32(byte_positions.shape[0]).view(
-            (np.byte, 4)
-        )
+        flatbuff[offset : offset + 4] = np.int32(byte_positions.shape[0]).tobytes()
         offset += 4
         flatbuff[offset : offset + byte_positions.nbytes] = byte_positions.reshape(
             -1
-        ).view(np.byte)
+        ).tobytes()
         offset += byte_positions.nbytes
 
     # Write actual data
     for byts in data:
         n = len(byts)
-        flatbuff[offset : offset + n] = np.frombuffer(byts, dtype=np.byte)
+        flatbuff[offset : offset + n] = byts
         offset += n
-    return memoryview(flatbuff.tobytes())
+    return memoryview(flatbuff)
 
 
 def deserialize_chunk(

--- a/hub/core/serialize.py
+++ b/hub/core/serialize.py
@@ -56,25 +56,24 @@ def serialize_chunk(
     """
     nbytes = infer_chunk_num_bytes(version, shape_info, byte_positions, data, len_data)
     flatbuff = bytearray(nbytes)
-    offset = 0
-
-    write_version(version, flatbuff, offset)
-    write_shape_info(shape_info, flatbuff, offset)
-    write_byte_positions(byte_positions, flatbuff, offset)
-    write_actual_data(data, flatbuff, offset)
+    offset = write_version(version, flatbuff)
+    offset = write_shape_info(shape_info, flatbuff, offset)
+    offset = write_byte_positions(byte_positions, flatbuff, offset)
+    offset = write_actual_data(data, flatbuff, offset)
     return memoryview(flatbuff)
 
 
-def write_version(version, buffer, offset):
-    """Writes version info to the buffer, takes offset into account and updates it."""
+def write_version(version, buffer) -> int:
+    """Writes version info to the buffer, returns offset."""
     len_version = len(version)
     buffer[0] = len_version
     buffer[1 : 1 + len_version] = list(map(ord, version))
-    offset += 1 + len_version
+    offset = 1 + len_version
+    return offset
 
 
-def write_shape_info(shape_info, buffer, offset):
-    """Writes shape info to the buffer, takes offset into account and updates it."""
+def write_shape_info(shape_info, buffer, offset) -> int:
+    """Writes shape info to the buffer, takes offset into account and returns updated offset."""
     if shape_info.ndim == 1:
         offset += 8
     else:
@@ -84,10 +83,11 @@ def write_shape_info(shape_info, buffer, offset):
 
         buffer[offset : offset + shape_info.nbytes] = shape_info.tobytes()
         offset += shape_info.nbytes
+    return offset
 
 
-def write_byte_positions(byte_positions, buffer, offset):
-    """Writes byte positions info to the buffer, takes offset into account and updates it."""
+def write_byte_positions(byte_positions, buffer, offset) -> int:
+    """Writes byte positions info to the buffer, takes offset into account and returns updated offset."""
     if byte_positions.ndim == 1:
         offset += 4
     else:
@@ -96,14 +96,16 @@ def write_byte_positions(byte_positions, buffer, offset):
 
         buffer[offset : offset + byte_positions.nbytes] = byte_positions.tobytes()
         offset += byte_positions.nbytes
+    return offset
 
 
-def write_actual_data(data, buffer, offset):
-    """Writes actual chunk data to the buffer, takes offset into account and updates it."""
+def write_actual_data(data, buffer, offset) -> int:
+    """Writes actual chunk data to the buffer, takes offset into account and returns updated offset"""
     for byts in data:
         n = len(byts)
         buffer[offset : offset + n] = byts
         offset += n
+    return offset
 
 
 def deserialize_chunk(

--- a/hub/core/storage/local.py
+++ b/hub/core/storage/local.py
@@ -77,8 +77,8 @@ class LocalProvider(StorageProvider):
                 raise FileAtPathException(directory)
             if not os.path.exists(directory):
                 os.makedirs(directory, exist_ok=True)
-            file = open(full_path, "wb")
-            file.write(value)
+            with open(full_path, "wb") as file:
+                file.write(value)
         except Exception:
             raise
 

--- a/hub/core/storage/local.py
+++ b/hub/core/storage/local.py
@@ -77,8 +77,8 @@ class LocalProvider(StorageProvider):
                 raise FileAtPathException(directory)
             if not os.path.exists(directory):
                 os.makedirs(directory, exist_ok=True)
-            with open(full_path, "wb") as file:
-                file.write(value)
+            file = open(full_path, "wb")
+            file.write(value)
         except Exception:
             raise
 


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [x]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [x]  I have commented my code, particularly in hard-to-understand areas
- [x]  I have kept the `coverage-rate` up
- [x]  I have performed a self-review of my own code and resolved any problems
- [x]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [x]  I have described and made corresponding changes to the relevant documentation
- [x]  New and existing unit tests pass locally with my changes


### Changes

Makes chunk serialization faster. Noticed around a 2x speedup when populating local datasets, s3 uploads are also slightly faster but didn't notice as big a difference, probably due to the network speeds being the bottleneck on my machine.