### PR TITLE
Fixes an issue with pytorch old read only

### DIFF
--- a/hub/core/storage/lru_cache.py
+++ b/hub/core/storage/lru_cache.py
@@ -57,9 +57,10 @@ class LRUCache(StorageProvider):
         This is a cascading function and leads to data being written to the final storage in case of a chained cache.
         """
         self.check_readonly()
-        for key in self.dirty_keys.copy():
-            self._forward(key)
-        self.next_storage.flush()
+        if self.dirty_keys:
+            for key in self.dirty_keys.copy():
+                self._forward(key)
+            self.next_storage.flush()
 
     def get_cachable(self, path: str, expected_class):
         """If the data at `path` was stored using the output of a `Cachable` object's `tobytes` function,

--- a/hub/integrations/pytorch/pytorch_old.py
+++ b/hub/integrations/pytorch/pytorch_old.py
@@ -1,18 +1,18 @@
+import os
+import pickle
+import warnings
+import hub
+from typing import Callable, Union, Optional, Dict, Tuple, Sequence
+from hub.core.storage import MemoryProvider, LRUCache
 from hub.util.dataset import try_flushing
-from hub.core.storage.memory import MemoryProvider
 from hub.util.remove_cache import get_base_storage
 from hub.util.iterable_ordered_dict import IterableOrderedDict
-from typing import Callable, Union, List, Optional, Dict, Tuple, Sequence
-import warnings
 from hub.util.exceptions import (
     DatasetUnsupportedPytorch,
     ModuleNotInstalledException,
     TensorDoesNotExistError,
 )
-import hub
-import os
-import pickle
-
+from hub.constants import MB
 from .common import convert_fn as default_convert_fn, collate_fn as default_collate_fn
 
 
@@ -82,7 +82,7 @@ class TorchDataset:
             raise DatasetUnsupportedPytorch(
                 "Datasets whose underlying storage is MemoryProvider are not supported for Pytorch iteration."
             )
-        self.pickled_storage = pickle.dumps(dataset.storage)
+        self.pickled_storage = pickle.dumps(base_storage)
         self.index = dataset.index
         self.length = len(dataset)
         self.transform = transform
@@ -103,8 +103,12 @@ class TorchDataset:
         """
         if self.dataset is None:
             storage = pickle.loads(self.pickled_storage)
+
+            # creating a new cache for each process
+            cache_size = 32 * MB * len(self.tensor_keys)
+            cached_storage = LRUCache(MemoryProvider(), storage, cache_size)
             self.dataset = hub.core.dataset.Dataset(
-                storage=storage, index=self.index, verbose=False
+                storage=cached_storage, index=self.index, verbose=False
             )
 
     def __len__(self):

--- a/hub/integrations/tests/test_pytorch.py
+++ b/hub/integrations/tests/test_pytorch.py
@@ -219,8 +219,6 @@ def test_custom_tensor_order(ds):
 
 @requires_torch
 def test_readonly(local_ds):
-    path = local_ds.path
-
     local_ds.create_tensor("images")
     local_ds.create_tensor("labels")
     local_ds.images.extend(np.ones((10, 28, 28)))
@@ -228,12 +226,13 @@ def test_readonly(local_ds):
 
     # this MUST be after all tensors have been created!
     update_chunk_sizes(local_ds, max_chunk_size=PYTORCH_TESTS_MAX_CHUNK_SIZE)
-
-    del local_ds
-
-    local_ds = hub.dataset(path)
-    local_ds.mode = "r"
+    base_storage = get_base_storage(local_ds.storage)
+    base_storage.enable_readonly()
+    ds = Dataset(storage=local_ds.storage, read_only=True, verbose=False)
 
     # no need to check input, only care that readonly works
-    for sample in local_ds.pytorch():
+    for _ in ds.pytorch():
+        pass
+
+    for _ in dataset_to_pytorch(ds):
         pass


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [x]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [x]  I have commented my code, particularly in hard-to-understand areas
- [x]  I have kept the `coverage-rate` up
- [x]  I have performed a self-review of my own code and resolved any problems
- [x]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [x]  I have described and made corresponding changes to the relevant documentation
- [x]  New and existing unit tests pass locally with my changes


### Changes

Fixes an issue with pytorch old read only, fixes the old test to ensure that this doesn't break in the future.