### PR TITLE
Delete .from_path() method

### DIFF
--- a/hub/core/dataset.py
+++ b/hub/core/dataset.py
@@ -450,30 +450,6 @@ class Dataset:
             self.client.delete_dataset_entry(self.org_id, self.ds_name)
             logger.info(f"Hub Dataset {self.path} successfully deleted.")
 
-    @staticmethod
-    def from_path(path: str):
-        """Creates a hub dataset from unstructured data.
-
-        Note:
-            This copies the data into hub format.
-            Be careful when using this with large datasets.
-
-        Args:
-            path (str): Path to the data to be converted
-
-        Returns:
-            A Dataset instance whose path points to the hub formatted
-            copy of the data.
-
-        Raises:
-            NotImplementedError: TODO.
-        """
-
-        raise NotImplementedError(
-            "Automatic dataset ingestion is not yet supported."
-        )  # TODO: hub.auto
-        return None
-
     def __str__(self):
         path_str = ""
         if self.path:


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [ ]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [ ]  I have performed a self-review of my own code and resolved any problems
- [ ]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [ ]  New and existing unit tests pass locally with my changes


### Changes

Remove unused method .from_path() from Dataset class.