### PR TITLE
Multi - SOF jpeg fix

### DIFF
--- a/hub/core/compression.py
+++ b/hub/core/compression.py
@@ -399,7 +399,7 @@ def read_meta_from_compressed_file(
             except Exception:
                 raise CorruptedSampleError("png")
         else:
-            img = Image.open(f) if isfile else Image.open(BytesIO(f))
+            img = Image.open(f) if isfile else Image.open(BytesIO(f))  # type: ignore
             shape, typestr = Image._conv_type_shape(img)
             compression = img.format.lower()
         return compression, shape, typestr  # type: ignore
@@ -408,13 +408,13 @@ def read_meta_from_compressed_file(
             f.close()
 
 
-def _read_jpeg_shape(f: Union[bytes, BinaryIO]) -> Tuple[int]:
+def _read_jpeg_shape(f: Union[bytes, BinaryIO]) -> Tuple[int, ...]:
     if hasattr(f, "read"):
         return _read_jpeg_shape_from_file(f)
     return _read_jpeg_shape_from_buffer(f)  # type: ignore
 
 
-def _read_jpeg_shape_from_file(f) -> Tuple[int]:
+def _read_jpeg_shape_from_file(f) -> Tuple[int, ...]:
     """Reads shape of a jpeg image from file without loading the whole image in memory"""
     mm = mmap.mmap(f.fileno(), 0, access=mmap.ACCESS_COPY)
     try:
@@ -434,7 +434,7 @@ def _read_jpeg_shape_from_file(f) -> Tuple[int]:
         mm.close()
 
 
-def _read_jpeg_shape_from_buffer(buf: bytes) -> Tuple[int]:
+def _read_jpeg_shape_from_buffer(buf: bytes) -> Tuple[int, ...]:
     """Gets shape of a jpeg file from its contents"""
     # Look for Start of Frame
     sof_idx = -1
@@ -448,7 +448,7 @@ def _read_jpeg_shape_from_buffer(buf: bytes) -> Tuple[int]:
     return shape
 
 
-def _read_png_shape_and_dtype(f: Union[bytes, BinaryIO]) -> Tuple[Tuple[int], str]:
+def _read_png_shape_and_dtype(f: Union[bytes, BinaryIO]) -> Tuple[Tuple[int, ...], str]:
     """Reads shape and dtype of a png file from a file like object or file contents.
     If a file like object is provided, all of its contents are NOT loaded into memory."""
     if not hasattr(f, "read"):

--- a/hub/core/compression.py
+++ b/hub/core/compression.py
@@ -413,7 +413,7 @@ def _read_jpeg_shape_from_file(f) -> Tuple[int]:
     try:
         # Look for Start of Frame
         sof_idx = -1
-        for sof_match in re.finditer(_JPEG_SOFS_RE, mm):
+        for sof_match in re.finditer(_JPEG_SOFS_RE, mm):  # type: ignore
             sof_idx = sof_match.start(0)
         if sof_idx == -1:
             raise Exception()

--- a/hub/core/compression.py
+++ b/hub/core/compression.py
@@ -227,7 +227,7 @@ def verify_compressed_file(
         if compression == "png":
             return _verify_png(file)
         elif compression == "jpeg":
-            return _verify_jpeg(file), "uint8"
+            return _verify_jpeg(file), "|u1"
         else:
             return _fast_decompress(file)
     except Exception as e:

--- a/hub/core/compression.py
+++ b/hub/core/compression.py
@@ -15,6 +15,7 @@ import mmap
 import struct
 import sys
 import re
+import lz4.frame  # type: ignore
 
 
 if sys.byteorder == "little":
@@ -24,7 +25,25 @@ else:
     _NATIVE_INT32 = ">i4"
     _NATIVE_FLOAT32 = ">f4"
 
-import lz4.frame  # type: ignore
+
+_JPEG_SOFS = [
+    b"\xff\xc0",
+    b"\xff\xc2",
+    b"\xff\xc1",
+    b"\xff\xc3",
+    b"\xff\xc5",
+    b"\xff\xc6",
+    b"\xff\xc7",
+    b"\xff\xc9",
+    b"\xff\xca",
+    b"\xff\xcb",
+    b"\xff\xcd",
+    b"\xff\xce",
+    b"\xff\xcf",
+    b"\xff\xde",
+]
+
+_JPEG_SOFS_RE = re.compile(b"|".join(_JPEG_SOFS))
 
 
 def to_image(array: np.ndarray) -> Image:
@@ -281,26 +300,6 @@ def _verify_jpeg_buffer(buf: bytes):
     shape = struct.unpack(">HHB", mview[sof_idx + 5 : sof_idx + 10])
     assert buf.find(b"\xff\xd9") != -1
     return shape
-
-
-_JPEG_SOFS = [
-    b"\xff\xc0",
-    b"\xff\xc2",
-    b"\xff\xc1",
-    b"\xff\xc3",
-    b"\xff\xc5",
-    b"\xff\xc6",
-    b"\xff\xc7",
-    b"\xff\xc9",
-    b"\xff\xca",
-    b"\xff\xcb",
-    b"\xff\xcd",
-    b"\xff\xce",
-    b"\xff\xcf",
-    b"\xff\xde",
-]
-
-_JPEG_SOFS_RE = re.compile(b"|".join(_JPEG_SOFS))
 
 
 def _verify_jpeg_file(f):

--- a/hub/core/compression.py
+++ b/hub/core/compression.py
@@ -285,8 +285,8 @@ def _verify_jpeg_buffer(buf: bytes):
 
 _JPEG_SOFS = [
     b"\xff\xc0",
-    b"\xff\xc1",
     b"\xff\xc2",
+    b"\xff\xc1",
     b"\xff\xc3",
     b"\xff\xc5",
     b"\xff\xc6",
@@ -299,6 +299,7 @@ _JPEG_SOFS = [
     b"\xff\xcf",
     b"\xff\xde",
 ]
+
 _JPEG_SOFS_RE = re.compile(b"|".join(_JPEG_SOFS))
 
 

--- a/hub/core/tests/test_compression.py
+++ b/hub/core/tests/test_compression.py
@@ -29,7 +29,7 @@ def test_array(compression, compressed_image_paths):
     if compression_type == BYTE_COMPRESSION:
         array = np.random.randint(0, 10, (32, 32))
     elif compression_type == IMAGE_COMPRESSION:
-        array = np.array(hub.read(compressed_image_paths[compression]))
+        array = np.array(hub.read(compressed_image_paths[compression][0]))
     shape = array.shape
     compressed_buffer = compress_array(array, compression)
     if compression_type == BYTE_COMPRESSION:
@@ -49,7 +49,7 @@ def test_array(compression, compressed_image_paths):
 def test_multi_array(compression, compressed_image_paths):
     compression_type = get_compression_type(compression)
     if compression_type == IMAGE_COMPRESSION:
-        img = Image.open(compressed_image_paths[compression])
+        img = Image.open(compressed_image_paths[compression][0])
         img2 = img.resize((img.size[0] // 2, img.size[1] // 2))
         img3 = img.resize((img.size[0] // 3, img.size[1] // 3))
         arrays = list(map(np.array, [img, img2, img3]))
@@ -73,14 +73,28 @@ def test_multi_array(compression, compressed_image_paths):
 
 @pytest.mark.parametrize("compression", image_compressions)
 def test_verify(compression, compressed_image_paths, corrupt_image_paths):
-    path = compressed_image_paths[compression]
-    sample = hub.read(path, verify=True)
-    sample.compressed_bytes(compression)
-    verify_compressed_file(path, compression)
-    with open(path, "rb") as f:
-        verify_compressed_file(f, compression)
-    with open(path, "rb") as f:
-        verify_compressed_file(f.read(), compression)
+    for path in compressed_image_paths[compression]:
+        sample = hub.read(path)
+        sample_loaded = hub.read(path)
+        sample_loaded = hub.read(path)
+        sample_loaded.compressed_bytes(compression)
+        sample_verified_and_loaded = hub.read(path, verify=True)
+        sample_verified_and_loaded.compressed_bytes(compression)
+        pil_image_shape = np.array(Image.open(path)).shape
+        assert (
+            sample.shape
+            == sample_loaded.shape
+            == sample_verified_and_loaded.shape
+            == pil_image_shape
+        ), (
+            sample.shape,
+            sample_loaded.shape,
+            sample_verified_and_loaded.shape,
+            pil_image_shape,
+        )
+        verify_compressed_file(path, compression)
+        with open(path, "rb") as f:
+            verify_compressed_file(f, compression)
     if compression in corrupt_image_paths:
         path = corrupt_image_paths[compression]
         sample = hub.read(path)

--- a/hub/core/tests/test_compression.py
+++ b/hub/core/tests/test_compression.py
@@ -76,7 +76,6 @@ def test_verify(compression, compressed_image_paths, corrupt_image_paths):
     for path in compressed_image_paths[compression]:
         sample = hub.read(path)
         sample_loaded = hub.read(path)
-        sample_loaded = hub.read(path)
         sample_loaded.compressed_bytes(compression)
         sample_verified_and_loaded = hub.read(path, verify=True)
         sample_verified_and_loaded.compressed_bytes(compression)

--- a/hub/integrations/tests/test_pytorch.py
+++ b/hub/integrations/tests/test_pytorch.py
@@ -233,7 +233,7 @@ def test_corrupt_dataset(local_ds, corrupt_image_paths, compressed_image_paths):
         with pytest.raises(DatasetUnsupportedPytorch):
             dl = local_ds.pytorch(num_workers=2)
         return
-    img_good = hub.read(compressed_image_paths["jpeg"])
+    img_good = hub.read(compressed_image_paths["jpeg"][0])
     img_bad = hub.read(corrupt_image_paths["jpeg"])
     with local_ds:
         local_ds.create_tensor("image", htype="image", sample_compression="jpeg")

--- a/hub/integrations/tests/test_tensorflow.py
+++ b/hub/integrations/tests/test_tensorflow.py
@@ -39,7 +39,7 @@ def test_tensorflow_small(local_ds):
 
 @requires_tensorflow
 def test_corrupt_dataset(local_ds, corrupt_image_paths, compressed_image_paths):
-    img_good = hub.read(compressed_image_paths["jpeg"])
+    img_good = hub.read(compressed_image_paths["jpeg"][0])
     img_bad = hub.read(corrupt_image_paths["jpeg"])
     with local_ds:
         local_ds.create_tensor("image", htype="image", sample_compression="jpeg")

--- a/hub/tests/path_fixtures.py
+++ b/hub/tests/path_fixtures.py
@@ -21,11 +21,51 @@ from hub.tests.common import (
     is_opt_true,
 )
 import pytest
+import requests
+import shutil
+import tempfile
+
 
 MEMORY = "memory"
 LOCAL = "local"
 S3 = "s3"
 HUB_CLOUD = "hub_cloud"
+
+
+def _download_pil_test_images(tempdir, ext=[".jpg", ".png"]):
+    paths = {e: [] for e in ext}
+    corrupt_file_keys = [
+        "broken",
+        "_dos",
+        "truncated",
+        "chunk_no_fctl",
+        "syntax_num_frames_zero",
+    ]
+    cwd = os.getcwd()
+    os.chdir(tempdir)
+    try:
+        os.system("git clone https://www.github.com/python-pillow/Pillow.git")
+        dirs = [
+            "Pillow/Tests/images",
+            "Pillow/Tests/images/apng",
+            "Pillow/Tests/images/imagedraw",
+        ]
+        for d in dirs:
+            for f in os.listdir(d):
+                brk = False
+                for k in corrupt_file_keys:
+                    if k in f:
+                        brk = True
+                        break
+                if brk:
+                    continue
+                for e in ext:
+                    if f.lower().endswith(e):
+                        paths[e].append(os.path.join(tempdir, d, f))
+                        break
+        return paths
+    finally:
+        os.chdir(cwd)
 
 
 def _get_path_composition_configs(request):
@@ -157,7 +197,7 @@ def flower_path():
     return os.path.join(path, "flower.png")
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def compressed_image_paths():
     paths = {
         "webp": "beach.webp",
@@ -181,7 +221,18 @@ def compressed_image_paths():
     for k in paths:
         paths[k] = os.path.join(parent, paths[k])
 
-    return paths
+    # Since we implement our own meta data reading for jpegs and pngs,
+    # we test against images from PIL repo to cover all edge cases.
+    paths = {k: [v] for k, v in paths.items()}
+    tmpdir = tempfile.mkdtemp()
+    pil_image_paths = _download_pil_test_images(tmpdir)
+    paths["jpeg"] += pil_image_paths[".jpg"]
+    paths["png"] += pil_image_paths[".png"]
+    yield paths
+    try:
+        shutil.rmtree(tmpdir)
+    except PermissionError:
+        pass
 
 
 @pytest.fixture


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [x]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [x]  I have commented my code, particularly in hard-to-understand areas
- [x]  I have kept the `coverage-rate` up
- [x]  I have performed a self-review of my own code and resolved any problems
- [x]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [x]  I have described and made corresponding changes to the relevant documentation
- [x]  New and existing unit tests pass locally with my changes


### Changes

Expect multiple SOF markers, pick the last one to find shape.