### PR TITLE
Treat size 1 arrays as scalars when casting

### DIFF
--- a/hub/api/tests/test_api.py
+++ b/hub/api/tests/test_api.py
@@ -222,7 +222,10 @@ def test_safe_downcasting(ds: Dataset):
     int_tensor.extend([5, 6, np.uint8(7)])
     with pytest.raises(TensorDtypeMismatchError):
         int_tensor.append(-8)
-    assert len(int_tensor) == 8
+    int_tensor.append(np.array([1]))
+    assert len(int_tensor) == 9
+    with pytest.raises(TensorDtypeMismatchError):
+        int_tensor.append(np.array([1.0]))
 
     float_tensor = ds.create_tensor("float", dtype="float32")
     float_tensor.append(0)
@@ -231,7 +234,9 @@ def test_safe_downcasting(ds: Dataset):
     float_tensor.extend([5.0, 6.0, np.float32(7.0)])
     with pytest.raises(TensorDtypeMismatchError):
         float_tensor.append(float(np.finfo(np.float32).max + 1))
-    assert len(float_tensor) == 8
+    float_tensor.append(np.array([1]))
+    float_tensor.append(np.array([1.0]))
+    assert len(float_tensor) == 10
 
 
 @enabled_datasets

--- a/hub/util/casting.py
+++ b/hub/util/casting.py
@@ -75,7 +75,9 @@ def get_incompatible_dtype(
     Raises:
         TypeError: if samples is of unexepcted type.
     """
-    if isinstance(samples, (int, float, bool, str)) or hasattr(samples, "dtype"):
+    if isinstance(samples, np.ndarray) and samples.size == 1:
+        samples = samples.reshape(1).tolist()[0]
+    if isinstance(samples, (int, float, bool)) or hasattr(samples, "dtype"):
         return (
             None
             if np.can_cast(samples, dtype)


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [ ]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [ ]  I have performed a self-review of my own code and resolved any problems
- [ ]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [ ]  New and existing unit tests pass locally with my changes


### Changes

https://activeloop.atlassian.net/browse/AL-1267

<!-- Describe your changes! Describe the scope of this PR's responsibilities. -->