### PR TITLE
fix running tests fails when no gcs creds exist

### DIFF
--- a/hub/tests/path_fixtures.py
+++ b/hub/tests/path_fixtures.py
@@ -178,7 +178,7 @@ def s3_path(request):
 
 @pytest.fixture(scope="session")
 def gcs_creds():
-    return os.environ[ENV_GOOGLE_APPLICATION_CREDENTIALS]
+    return os.environ.get(ENV_GOOGLE_APPLICATION_CREDENTIALS, None)
 
 
 @pytest.fixture


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [ ]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [ ]  I have performed a self-review of my own code and resolved any problems
- [ ]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [ ]  New and existing unit tests pass locally with my changes


### Changes

<!-- Describe your changes! Describe the scope of this PR's responsibilities. -->

lets you run `pytest .` without gcs creds. no functionality change, just fixes a headache