### PR TITLE
lz4 backward compatibility

### DIFF
--- a/hub/core/compression.py
+++ b/hub/core/compression.py
@@ -16,10 +16,7 @@ import struct
 import sys
 import re
 import numcodecs.lz4  # type: ignore
-<<<<<<< HEAD
 import lz4.frame  # type: ignore
-=======
->>>>>>> 646d42b7b84d69aed45f437d9d13e47fba1349e3
 
 
 if sys.byteorder == "little":

--- a/hub/core/compression.py
+++ b/hub/core/compression.py
@@ -15,7 +15,7 @@ import mmap
 import struct
 import sys
 import re
-import lz4.frame  # type: ignore
+import numcodecs.lz4  # type: ignore
 
 
 if sys.byteorder == "little":
@@ -73,7 +73,7 @@ def to_image(array: np.ndarray) -> Image:
 
 def compress_bytes(buffer: Union[bytes, memoryview], compression: str) -> bytes:
     if compression == "lz4":
-        return lz4.frame.compress(buffer)
+        return numcodecs.lz4.compress(buffer)
     else:
         raise SampleCompressionError(
             (len(buffer),), compression, f"Not a byte compression: {compression}"
@@ -82,7 +82,7 @@ def compress_bytes(buffer: Union[bytes, memoryview], compression: str) -> bytes:
 
 def decompress_bytes(buffer: Union[bytes, memoryview], compression: str) -> bytes:
     if compression == "lz4":
-        return lz4.frame.decompress(buffer)
+        return numcodecs.lz4.decompress(buffer)
     else:
         raise SampleDecompressionError()
 

--- a/hub/core/compression.py
+++ b/hub/core/compression.py
@@ -83,7 +83,9 @@ def compress_bytes(buffer: Union[bytes, memoryview], compression: str) -> bytes:
 
 def decompress_bytes(buffer: Union[bytes, memoryview], compression: str) -> bytes:
     if compression == "lz4":
-        if buffer[:4] == b'\x04"M\x18':
+        if (
+            buffer[:4] == b'\x04"M\x18'
+        ):  # python-lz4 magic number (backward compatiblity)
             return lz4.frame.decompress(buffer)
         return numcodecs.lz4.decompress(buffer)
     else:

--- a/hub/core/compression.py
+++ b/hub/core/compression.py
@@ -16,6 +16,7 @@ import struct
 import sys
 import re
 import numcodecs.lz4  # type: ignore
+import lz4.frame  # type: ignore
 
 
 if sys.byteorder == "little":
@@ -82,6 +83,8 @@ def compress_bytes(buffer: Union[bytes, memoryview], compression: str) -> bytes:
 
 def decompress_bytes(buffer: Union[bytes, memoryview], compression: str) -> bytes:
     if compression == "lz4":
+        if buffer[:4] == b'\x04"M\x18':
+            return lz4.frame.decompress(buffer)
         return numcodecs.lz4.decompress(buffer)
     else:
         raise SampleDecompressionError()

--- a/hub/core/tests/test_compression.py
+++ b/hub/core/tests/test_compression.py
@@ -117,5 +117,5 @@ def test_verify(compression, compressed_image_paths, corrupt_image_paths):
 def test_lz4_bc():
     inp = np.random.random((100, 100)).tobytes()
     compressed = lz4.frame.compress(inp)
-    decompressed = decompress_bytes(compressed)
+    decompressed = decompress_bytes(compressed, "lz4")
     assert decompressed == inp

--- a/hub/core/tests/test_compression.py
+++ b/hub/core/tests/test_compression.py
@@ -2,12 +2,14 @@ from hub.tests.common import get_actual_compression_from_buffer, assert_images_c
 import numpy as np
 import pytest
 import hub
+import lz4.frame
 from hub.core.compression import (
     compress_array,
     decompress_array,
     compress_multiple,
     decompress_multiple,
     verify_compressed_file,
+    decompress_bytes,
 )
 from hub.compression import get_compression_type, BYTE_COMPRESSION, IMAGE_COMPRESSION
 from hub.util.exceptions import CorruptedSampleError
@@ -110,3 +112,10 @@ def test_verify(compression, compressed_image_paths, corrupt_image_paths):
         with pytest.raises(CorruptedSampleError):
             with open(path, "rb") as f:
                 verify_compressed_file(f.read(), compression)
+
+
+def test_lz4_bc():
+    inp = np.random.random((100, 100)).tobytes()
+    compressed = lz4.frame.compress(inp)
+    decompressed = decompress_bytes(compressed)
+    assert decompressed == inp

--- a/hub/requirements/common.txt
+++ b/hub/requirements/common.txt
@@ -12,4 +12,4 @@ types-click
 tqdm
 lz4
 typing_extensions>=3.10.0.0
-numcodecs==0.7.3
+numcodecs~=0.7.3

--- a/hub/requirements/requirements.txt
+++ b/hub/requirements/requirements.txt
@@ -4,6 +4,7 @@ click~=7.1.2
 boto3~=1.17.43
 botocore~=1.20.78
 numcodecs~=0.7.3
+lz4~=3.1.3
 Pillow~=8.2.0
 zstd~=1.4.5
 requests~=2.25.1

--- a/hub/requirements/requirements.txt
+++ b/hub/requirements/requirements.txt
@@ -5,6 +5,5 @@ boto3~=1.17.43
 botocore~=1.20.78
 numcodecs~=0.7.3
 Pillow~=8.2.0
-lz4~=3.1.3
 zstd~=1.4.5
 requests~=2.25.1


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [x]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [x]  I have commented my code, particularly in hard-to-understand areas
- [x]  I have kept the `coverage-rate` up
- [x]  I have performed a self-review of my own code and resolved any problems
- [x]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [x]  New and existing unit tests pass locally with my changes


### Changes

BC for dataset compressed with lz4.frame

<!-- Describe your changes! Describe the scope of this PR's responsibilities. -->