### PR TITLE
Bring back "Linux Timple Test"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,12 @@ workflows:
   test:
     jobs:
       - test:
+          name: "Linux Simple Test"
+          e: linux38
+          context:
+            - test
+            - azure
+      - test:
           name: "Linux Complex Test: Python 3.6"
           e: linux36
           plugins: true
@@ -60,9 +66,17 @@ workflows:
             - test
             - azure
           filters: *version
+      - test:
+          name: test-simple-python-38
+          e: linux38
+          context:
+            - test
+            - azure
+          filters: *version
       - verify:
           type: approval
           requires:
+            - test-simple-python-38
             - test-complex-python-36
             - test-complex-python-38
           filters: *version


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [ ]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [ ]  I have performed a self-review of my own code and resolved any problems
- [ ]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [ ]  New and existing unit tests pass locally with my changes


### Changes

This PR brings back the "Linux Simple Test" for testing `hub` without plugins.