### PR TITLE
[BURNING] terms of access

### DIFF
--- a/hub/api/tests/test_terms_of_access.py
+++ b/hub/api/tests/test_terms_of_access.py
@@ -1,0 +1,57 @@
+import pytest
+import hub
+from hub.tests.common import assert_array_lists_equal
+import sys
+from contextlib import contextmanager
+from io import StringIO
+from hub.util.exceptions import UnagreedTermsOfAccessError
+
+
+@contextmanager
+def replace_stdin(target):
+    orig = sys.stdin
+    sys.stdin = target
+    yield
+    sys.stdin = orig
+
+
+def dont_agree(path):
+    """Load the hub cloud dataset at path and simulate disagreeing to the terms of access."""
+
+    with pytest.raises(UnagreedTermsOfAccessError):
+        # this text can be anything except expected
+        with replace_stdin(StringIO("no, i don't agree!")):
+            hub.load(path)
+
+
+def agree(path):
+    """Load the hub cloud dataset at path and simulate agreeing to the terms of access."""
+
+    dataset_name = path.split("/")[-1]
+    with replace_stdin(StringIO(dataset_name)):
+        ds = hub.load(path)
+    assert_array_lists_equal(ds.test.numpy(), [[1, 2, 3]])
+
+
+def test_creator_has_access(hub_cloud_ds_generator):
+    gen = hub_cloud_ds_generator
+    ds = gen()
+    path = ds.path
+
+    ds.add_terms_of_access("only nerdz allowed")
+    ds.create_tensor("test")
+    ds.test.append([1, 2, 3])
+
+    # access granted by default since this is the creator of the dataset
+    ds = gen()
+    assert_array_lists_equal(ds.test.numpy(), [[1, 2, 3]])
+
+    # revoke access
+    ds.client._respond_to_terms_of_access(ds.org_id, ds.ds_name, "disagree")
+    del ds
+
+    # access NOT granted
+    dont_agree(path)
+
+    # ds = gen()
+    agree(path)

--- a/hub/client/client.py
+++ b/hub/client/client.py
@@ -1,9 +1,18 @@
 import hub
 import requests
 from typing import Optional
-from hub.util.exceptions import LoginException, InvalidPasswordException, UnagreedTermsOfAccessError
+from hub.util.exceptions import (
+    LoginException,
+    InvalidPasswordException,
+    UnagreedTermsOfAccessError,
+)
 from hub.util.terms_of_access import terms_of_access_prompt
-from hub.client.utils import check_response_status, write_token, read_token, get_user_name
+from hub.client.utils import (
+    check_response_status,
+    write_token,
+    read_token,
+    get_user_name,
+)
 from hub.client.config import (
     HUB_REST_ENDPOINT,
     HUB_REST_ENDPOINT_LOCAL,
@@ -165,7 +174,7 @@ class HubBackendClient:
             ds_name (str): The name of the dataset being accessed.
             mode (str, optional): The mode in which the user has requested to open the dataset.
                 If not provided, the backend will set mode to 'a' if user has write permission, else 'r'.
-        
+
         Raises:
             LoginException: Datasets with terms of access require user login.
             UnagreedTermsOfAccessError: Disagreeing with terms of access.

--- a/hub/client/config.py
+++ b/hub/client/config.py
@@ -17,6 +17,8 @@ DATASET_SUFFIX = "/api/dataset"
 UPDATE_SUFFIX = "/api/org/{}/dataset/{}"
 LIST_DATASETS = "/api/datasets/{}"
 GET_USER_PROFILE = "/api/user/profile"
+ADD_TERMS_OF_ACCESS_SUFFIX = "/api/org/{}/ds/{}/terms"
+RESPOND_TO_TERMS_OF_ACCESS_SUFFIX = "/api/org/{}/ds/{}/terms/{}"
 
 DEFAULT_REQUEST_TIMEOUT = 170
 

--- a/hub/client/utils.py
+++ b/hub/client/utils.py
@@ -21,6 +21,7 @@ from hub.util.exceptions import (
     ServerException,
     UnexpectedStatusCodeException,
     InvalidTokenException,
+    UnagreedTermsOfAccessError,
 )
 
 
@@ -68,6 +69,10 @@ def check_response_status(response: requests.Response):
     elif response.status_code == 401:
         raise AuthenticationException
     elif response.status_code == 403:
+        payload = response.json()
+        if "terms" in payload:
+            raise UnagreedTermsOfAccessError(payload["terms"])
+
         raise AuthorizationException(message)
     elif response.status_code == 404:
         if message != " ":

--- a/hub/core/dataset/hub_cloud_dataset.py
+++ b/hub/core/dataset/hub_cloud_dataset.py
@@ -80,3 +80,16 @@ class HubCloudDataset(Dataset):
 
         self.client.delete_dataset_entry(self.org_id, self.ds_name)
         logger.info(f"Hub Dataset {self.path} successfully deleted.")
+
+    def check_credentials(self):
+        """If terms of access are unagreed to, this method will raise an error and trigger
+        user-interaction requirement for agreeing. It's basically just an alias for `get_dataset_credentials`
+        """
+
+        self.client.get_dataset_credentials(self.org_id, self.ds_name)
+
+    def add_terms_of_access(self, terms: str):
+        """Users must agree to these terms before being able to access this dataset."""
+
+        self.check_credentials()
+        self.client.add_terms_of_access(self.org_id, self.ds_name, terms)

--- a/hub/util/exceptions.py
+++ b/hub/util/exceptions.py
@@ -612,4 +612,3 @@ class UnagreedTermsOfAccessError(Exception):
             "The terms of access must first be agreed to before you can access this dataset."
         )
         self.terms = terms
-

--- a/hub/util/exceptions.py
+++ b/hub/util/exceptions.py
@@ -604,3 +604,12 @@ class GCSDefaultCredsNotFoundError(Exception):
             "Unable to find default google application credentials at ~/.config/gcloud/application_default_credentials.json. "
             "Please make sure you initialized gcloud service earlier."
         )
+
+
+class UnagreedTermsOfAccessError(Exception):
+    def __init__(self, terms: str):
+        super().__init__(
+            "The terms of access must first be agreed to before you can access this dataset."
+        )
+        self.terms = terms
+

--- a/hub/util/terms_of_access.py
+++ b/hub/util/terms_of_access.py
@@ -1,0 +1,23 @@
+def terms_of_access_prompt(dataset_org: str, dataset_name: str, terms: str):
+    print()
+    print()
+    print(
+        "The owner of the dataset you are trying to access requires that you agree to the following terms first:"
+    )
+    print()
+    print("-" * 16)
+    print(f"Dataset Owner: {dataset_org}")
+    print(f"Dataset Name: {dataset_name}")
+    print("-" * 16)
+
+    print("Terms:")
+    print(terms)
+    print()
+    print()
+
+    print("-" * 16)
+    x = input(
+        f"In order to accept, please type the dataset's name ({dataset_name}) and press enter: "
+    )
+
+    return x == dataset_name


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [x]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [x]  I have commented my code, particularly in hard-to-understand areas
- [x]  I have kept the `coverage-rate` up
- [x]  I have performed a self-review of my own code and resolved any problems
- [x]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [x]  I have described and made corresponding changes to the relevant documentation
- [x]  New and existing unit tests pass locally with my changes


### Changes

using this API:

```python
ds.add_terms_of_access("nerdz only")
```

you require users to agree to the terms you specify. when a user tries to load the dataset for the first time, they are prompted with the terms and are told to enter the dataset's name.