### PR TITLE
Fix to ensure agreement isn't reloaded for each slice of dataset

### DIFF
--- a/hub/api/tests/test_pickle.py
+++ b/hub/api/tests/test_pickle.py
@@ -2,10 +2,13 @@ import numpy as np
 import pytest
 from hub.util.exceptions import MemoryDatasetCanNotBePickledError
 import pickle
-from hub.tests.dataset_fixtures import enabled_datasets
 
 
-@enabled_datasets
+@pytest.mark.parametrize(
+    "ds",
+    ["memory_ds", "local_ds", "s3_ds", "gcs_ds", "hub_cloud_ds"],
+    indirect=True,
+)
 def test_dataset(ds):
     if ds.path.startswith("mem://"):
         with pytest.raises(MemoryDatasetCanNotBePickledError):

--- a/hub/core/dataset/dataset.py
+++ b/hub/core/dataset/dataset.py
@@ -108,6 +108,7 @@ class Dataset:
         self._token = token
         self.public = public
         self.verbose = verbose
+        self.is_first_load = version_state is None
         self.version_state: Dict[str, Any] = version_state or {}
         self._info = None
         self._set_derived_attributes()
@@ -172,6 +173,7 @@ class Dataset:
             state (dict): The pickled state used to restore the dataset.
         """
         self.__dict__.update(state)
+        self.is_first_load = True
         self._info = None
         self._set_derived_attributes()
 

--- a/hub/core/dataset/hub_cloud_dataset.py
+++ b/hub/core/dataset/hub_cloud_dataset.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Any, Dict, Optional
 from hub.constants import AGREEMENT_FILENAME, HUB_CLOUD_DEV_USERNAME
 from hub.core.dataset import Dataset
 from hub.client.client import HubBackendClient
@@ -16,17 +16,19 @@ class HubCloudDataset(Dataset):
         self._set_org_and_name()
 
         super().__init__(*args, **kwargs)
+        self.first_load_init()
 
-        if self.is_actually_cloud:
-            if self.is_first_load:
+    def first_load_init(self):
+        if self.is_first_load:
+            if self.is_actually_cloud:
                 handle_dataset_agreement(
-                    self.agreement, path, self.ds_name, self.org_id
+                    self.agreement, self.path, self.ds_name, self.org_id
                 )
-        else:
-            # NOTE: this can happen if you override `hub.core.dataset.FORCE_CLASS`
-            warn(
-                f'Created a hub cloud dataset @ "{self.path}" which does not have the "hub://" prefix. Note: this dataset should only be used for testing!'
-            )
+            else:
+                # NOTE: this can happen if you override `hub.core.dataset.FORCE_CLASS`
+                warn(
+                    f'Created a hub cloud dataset @ "{self.path}" which does not have the "hub://" prefix. Note: this dataset should only be used for testing!'
+                )
 
     @property
     def client(self):
@@ -97,3 +99,14 @@ class HubCloudDataset(Dataset):
     def add_agreeement(self, agreement: str):
         self.storage.check_readonly()
         self.storage[AGREEMENT_FILENAME] = agreement.encode("utf-8")
+
+    def __getstate__(self) -> Dict[str, Any]:
+        state = super().__getstate__()
+        state["org_id"] = self.org_id
+        state["ds_name"] = self.ds_name
+        return state
+
+    def __setstate__(self, state: Dict[str, Any]):
+        super().__setstate__(state)
+        self._client = None
+        self.first_load_init()

--- a/hub/core/dataset/hub_cloud_dataset.py
+++ b/hub/core/dataset/hub_cloud_dataset.py
@@ -17,7 +17,7 @@ class HubCloudDataset(Dataset):
 
         super().__init__(*args, **kwargs)
 
-        if self.is_actually_cloud:
+        if self.is_actually_cloud and self.is_first_load:
             handle_dataset_agreement(self.agreement, path, self.ds_name, self.org_id)
         else:
             # NOTE: this can happen if you override `hub.core.dataset.FORCE_CLASS`

--- a/hub/core/dataset/hub_cloud_dataset.py
+++ b/hub/core/dataset/hub_cloud_dataset.py
@@ -17,8 +17,11 @@ class HubCloudDataset(Dataset):
 
         super().__init__(*args, **kwargs)
 
-        if self.is_actually_cloud and self.is_first_load:
-            handle_dataset_agreement(self.agreement, path, self.ds_name, self.org_id)
+        if self.is_actually_cloud:
+            if self.is_first_load:
+                handle_dataset_agreement(
+                    self.agreement, path, self.ds_name, self.org_id
+                )
         else:
             # NOTE: this can happen if you override `hub.core.dataset.FORCE_CLASS`
             warn(


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [x]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [x]  I have commented my code, particularly in hard-to-understand areas
- [x]  I have kept the `coverage-rate` up
- [x]  I have performed a self-review of my own code and resolved any problems
- [x]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [x]  I have described and made corresponding changes to the relevant documentation
- [x]  New and existing unit tests pass locally with my changes


### Changes

Ensures that the dataset agreement is only loaded once for each Dataset instance