### PR TITLE
[AL-1565] Filtering with simple query language

### DIFF
--- a/hub/core/compute/process.py
+++ b/hub/core/compute/process.py
@@ -1,14 +1,19 @@
 from hub.core.compute.provider import ComputeProvider
 from pathos.pools import ProcessPool  # type: ignore
+from pathos.helpers import mp as pathos_multiprocess  # type: ignore
 
 
 class ProcessProvider(ComputeProvider):
     def __init__(self, workers):
         self.workers = workers
         self.pool = ProcessPool(nodes=workers)
+        self.manager = pathos_multiprocess.Manager()
 
     def map(self, func, iterable):
         return self.pool.map(func, iterable)
+
+    def create_queue(self):
+        return self.manager.Queue()
 
     def close(self):
         self.pool.close()

--- a/hub/core/compute/provider.py
+++ b/hub/core/compute/provider.py
@@ -1,12 +1,55 @@
 from abc import ABC, abstractmethod
 
 
-# TODO, will probably also need Queue to get tqdm working properly
 class ComputeProvider(ABC):
     """An abstract base class for implementing a compute provider."""
 
     def __init__(self, workers):
         self.workers = workers
+
+    def map_with_progressbar(self, func, iterable, total_length: int):
+        from tqdm.std import tqdm  # type: ignore
+        import threading
+        from threading import Thread
+
+        progress_bar = tqdm(total=total_length)
+        progress_queue = self.create_queue()
+
+        def sub_func(*args, **kwargs):
+            def pg_callback(value: int):
+                progress_queue.put(value)  # type: ignore[trust]
+                pass
+
+            return func(pg_callback, *args, **kwargs)
+
+        def update_pg(bar, queue):
+            while True:
+                r = queue.get()
+                if r is not None:
+                    bar.update(r)
+                else:
+                    break
+
+        progress_thread: Thread = threading.Thread(
+            target=update_pg, args=(progress_bar, progress_queue)
+        )
+        progress_thread.start()
+
+        try:
+            result = self.map(sub_func, iterable)
+        finally:
+            progress_bar.close()
+            progress_queue.put(None)  # type: ignore[trust]
+            progress_thread.join()
+
+            if hasattr(progress_queue, "close"):
+                progress_bar.close()
+
+        return result
+
+    @abstractmethod
+    def create_queue(self):
+        """Creates queue for specific provider"""
 
     @abstractmethod
     def map(self, func, iterable):

--- a/hub/core/compute/ray.py
+++ b/hub/core/compute/ray.py
@@ -1,10 +1,13 @@
 import ray
 from ray.util.multiprocessing import Pool
+from ray.util.queue import Queue
 from hub.core.compute.provider import ComputeProvider
 
 
 class RayProvider(ComputeProvider):
     def __init__(self, workers):
+        super().__init__(workers)
+
         if not ray.is_initialized():
             ray.init()
         self.workers = workers
@@ -16,3 +19,6 @@ class RayProvider(ComputeProvider):
     def close(self):
         self.pool.close()
         self.pool.join()
+
+    def create_queue(self):
+        return Queue()

--- a/hub/core/compute/serial.py
+++ b/hub/core/compute/serial.py
@@ -8,5 +8,18 @@ class SerialProvider(ComputeProvider):
     def map(self, func, iterable):
         return list(map(func, iterable))
 
+    def map_with_progressbar(self, func, iterable, total_length: int):
+        from tqdm.std import tqdm  # type: ignore
+
+        result = list()
+
+        for x in tqdm(iterable, total=total_length):
+            result.append(func(x))
+
+        return result
+
+    def create_queue(self):
+        raise NotImplementedError("no queues in serial provider")
+
     def close(self):
         return

--- a/hub/core/compute/thread.py
+++ b/hub/core/compute/thread.py
@@ -1,3 +1,4 @@
+from multiprocessing import Manager
 from hub.core.compute.provider import ComputeProvider
 from pathos.pools import ThreadPool  # type: ignore
 
@@ -5,10 +6,14 @@ from pathos.pools import ThreadPool  # type: ignore
 class ThreadProvider(ComputeProvider):
     def __init__(self, workers):
         self.workers = workers
+        self.manager = Manager()
         self.pool = ThreadPool(nodes=workers)
 
     def map(self, func, iterable):
         return self.pool.map(func, iterable)
+
+    def create_queue(self):
+        return self.manager.Queue()
 
     def close(self):
         self.pool.close()

--- a/hub/core/dataset/dataset.py
+++ b/hub/core/dataset/dataset.py
@@ -594,6 +594,49 @@ class Dataset:
 
         return dataloader
 
+    @hub_reporter.record_call
+    def filter(
+        self,
+        function: Union[Callable, str],
+        num_workers: int = 0,
+        scheduler: str = "threaded",
+        progressbar: bool = True,
+    ):
+        """Filters the dataset in accordance of filter function `f(x: sample) -> bool`
+
+        Args:
+            function(Callable | str): filter function that takes sample as argument and returns True/False
+                if sample should be included in result. Also supports simplified expression evaluations.
+                See hub.core.query.DatasetQuery for more details.
+            num_workers(int): level of parallelization of filter evaluations.
+                `0` indicates in-place for-loop evaluation, multiprocessing is used otherwise.
+            scheduler(str): scheduler to use for multiprocessing evaluation.
+                `threaded` is default
+            progressbar(bool): display progress bar while filtering. True is default
+
+        Returns:
+            View on Dataset with elements, that satisfy filter function
+
+
+        Example:
+            Following filters are identical and return dataset view where all the samples have label equals to 2.
+            >>> dataset.filter(lambda sample: sample.labels.numpy() == 2)
+            >>> dataset.filter('labels == 2')
+        """
+        from hub.core.query import filter_dataset
+        from hub.core.query import DatasetQuery
+
+        if isinstance(function, str):
+            function = DatasetQuery(self, function)
+
+        return filter_dataset(
+            self,
+            function,
+            num_workers=num_workers,
+            scheduler=scheduler,
+            progressbar=progressbar,
+        )
+
     def _get_total_meta(self):
         """Returns tensor metas all together"""
         return {

--- a/hub/core/query/__init__.py
+++ b/hub/core/query/__init__.py
@@ -1,0 +1,2 @@
+from .query import DatasetQuery
+from .filter import filter_dataset

--- a/hub/core/query/filter.py
+++ b/hub/core/query/filter.py
@@ -1,0 +1,89 @@
+from typing import Callable, List, Sequence
+
+import hub
+
+from hub.core.io import SampleStreaming
+from hub.util.compute import get_compute_provider
+from hub.util.dataset import map_tensor_keys
+
+
+def filter_dataset(
+    dataset: hub.Dataset,
+    filter_function: Callable[[hub.Dataset], bool],
+    num_workers: int = 0,
+    scheduler: str = "threaded",
+    progressbar: bool = True,
+) -> hub.Dataset:
+    index_map: List[int]
+
+    if num_workers > 0:
+        index_map = filter_with_compute(
+            dataset, filter_function, num_workers, scheduler, progressbar
+        )
+    else:
+        index_map = filter_inplace(dataset, filter_function, progressbar)
+
+    return dataset[index_map]  # type: ignore [this is fine]
+
+
+def filter_with_compute(
+    dataset: hub.Dataset,
+    filter_function: Callable,
+    num_workers: int,
+    scheduler: str,
+    progressbar: bool = True,
+) -> List[int]:
+
+    blocks = SampleStreaming(dataset, tensors=map_tensor_keys(dataset)).list_blocks()
+    compute = get_compute_provider(scheduler=scheduler, num_workers=num_workers)
+
+    def filter_slice(indices: Sequence[int]):
+        result = list()
+        for i in indices:
+            if filter_function(dataset[i]):
+                result.append(i)
+
+        return result
+
+    def pg_filter_slice(pg_callback, indices: Sequence[int]):
+        result = list()
+        for i in indices:
+            pg_callback(1)
+            if filter_function(dataset[i]):
+                result.append(i)
+
+        return result
+
+    result: Sequence[List[int]]
+    idx: List[List[int]] = [block.indices() for block in blocks]
+
+    try:
+        if progressbar:
+            result = compute.map_with_progressbar(pg_filter_slice, idx, total_length=len(dataset))  # type: ignore
+        else:
+            result = compute.map(filter_slice, idx)  # type: ignore
+        index_map = [k for x in result for k in x]  # unfold the result map
+
+    finally:
+        compute.close()
+
+    return index_map
+
+
+def filter_inplace(
+    dataset: hub.Dataset, filter_function: Callable, progressbar: bool
+) -> List[int]:
+    index_map: List[int] = list()
+
+    it = enumerate(dataset)
+
+    if progressbar:
+        from tqdm import tqdm  # type: ignore
+
+        it = tqdm(it, total=len(dataset))
+
+    for i, sample_in in it:
+        if filter_function(sample_in):
+            index_map.append(i)
+
+    return index_map

--- a/hub/core/query/query.py
+++ b/hub/core/query/query.py
@@ -1,0 +1,272 @@
+from abc import ABC
+from typing import Any, Dict
+
+import hub
+import json
+import numpy as np
+
+from hub.core.tensor import Tensor
+
+
+class DatasetQuery:
+    """Dataset query function which is defined by the query string.
+    Designed not to be used directly, but passed as a function parameter to
+    `dataset.filter()`
+
+    Example:
+
+    >>> query = DatasetQuery(dataset, 'images[1:3].min == 0')
+    >>> query = DatasetQuery(dataset, 'labels > 5')
+    >>> query(sample_in)
+    True
+    """
+
+    def __init__(self, dataset: hub.Dataset, query: str):
+        self._dataset = dataset
+        self._query = query
+        self.global_vars: Dict[str, Any] = dict()
+
+    def __call__(self, *args: Any) -> bool:
+        return self._call_eval(*args)
+
+    def _call_eval(self, sample_in: hub.Dataset):
+        return eval(
+            self._query, {}, self._export_tensors(sample_in)
+        )  # TODO export tensors create new bindings. Can we update instead ?
+
+    def _export_tensors(self, sample_in):
+        bindings = {"dataset": sample_in}
+
+        for key, tensor in sample_in.tensors.items():
+            if tensor.htype == "class_label":
+                bindings[key] = EvalLabelClassTensor(tensor)
+                for label in tensor.info["class_names"]:
+                    bindings[label] = label
+            elif tensor.htype == "text":
+                bindings[key] = EvalTextTesor(tensor)
+            elif tensor.htype == "json":
+                bindings[key] = EvalJsonTensor(tensor)
+            elif "/" in key:
+                group, tensor_name = key.split("/")
+
+                if not group in bindings:
+                    bindings[group] = EvalGroupTensor(group)
+                bindings[group].extend(tensor_name, tensor)
+
+            else:
+                bindings[key] = EvalGenericTensor(tensor)
+
+        return bindings
+
+    def __repr__(self) -> str:
+        return f"'{self._query}' on {self._dataset}"
+
+
+class EvalObject(ABC):
+    pass
+
+
+class EvalTensorObject(EvalObject):
+    def __init__(self, tensor: Tensor) -> None:
+        super().__init__()
+        self._tensor = tensor
+        self._cached_value: Any = None
+        self._is_cached_value: bool = False
+
+    def is_scalar(self):
+        return self.numpy().size == 1  # type: ignore
+
+    def as_scalar(self):
+        if self.is_scalar():
+            return self.numpy()[0]
+        else:
+            raise ValueError("Not a scalar")
+
+    def numpy(self):
+        """Retrives and caches value"""
+        if not self._is_cached_value:
+            self._cached_value = self._tensor.numpy()
+            self._is_cached_value = True
+
+        return self._cached_value
+
+
+class ScalarTensorObject(EvalObject):
+    """Abstract subclass defining operations on a scalars.
+    Requires override of  `as_scalar()` to enable operations set of [ = > < >= <= != ]
+    """
+
+    def as_scalar(self) -> Any:
+        raise NotImplementedError
+
+    def __eq__(self, o: object) -> bool:
+        return self.as_scalar() == o
+
+    def __lt__(self, o: object) -> bool:
+        return self.as_scalar() < o
+
+    def __le__(self, o: object) -> bool:
+        return self.as_scalar() <= o
+
+    def __gt__(self, o: object) -> bool:
+        return self.as_scalar() > o
+
+    def __ge__(self, o: object) -> bool:
+        return self.as_scalar() >= o
+
+    def __ne__(self, o: object) -> bool:
+        return self.as_scalar() != o
+
+
+class EvalGenericTensor(EvalTensorObject, ScalarTensorObject):
+    """Wrapper of tensor for evaluation function `eval()` which provides simplified interface to work
+    with a tensor.
+
+    Defines functions available on tensor `t`
+    >>> t = tensor(np.array(...))
+    >>> t.min == t.numpy.min()
+    >>> t.max == t.numpy.max()
+    >>> t.mean == t.numpy.mean()
+    >>> t.shape == t.numpy.shape
+    >>> t.size == t.numpy.size
+
+
+    Enables scalar operations, if tensor is size of 1.
+    >>> t = tensor([4])
+    >>> t > 3 or t < 5
+    True
+    """
+
+    def __init__(self, tensor: Tensor) -> None:
+        super().__init__(tensor)
+
+    @property
+    def min(self):
+        """Returns numpy.min() for the tensor"""
+        return np.amin(self.numpy())
+
+    @property
+    def max(self):
+        """Returns numpy.max() for the tensor"""
+        return np.amax(self.numpy())
+
+    @property
+    def mean(self):
+        """Returns numpy.mean() for the tensor"""
+        return np.mean(self.numpy())
+
+    @property
+    def shape(self):
+        """Returns shape of the underlying numpy array"""
+        return self.numpy().shape  # type: ignore
+
+    @property
+    def size(self):
+        """Returns size of the underlying numpy array"""
+        return self.numpy().size  # type: ignore
+
+    def contains(self, o: object) -> bool:
+        return any(self.numpy() == o)  # type: ignore
+
+    def __getitem__(self, item):
+        """Returns subscript of underlying numpy array or a scalar"""
+        val = self.numpy()[item]
+
+        if isinstance(val, np.ndarray):
+            return EvalGenericTensor(self._tensor[item])
+        else:
+            return val
+
+
+class EvalLabelClassTensor(EvalTensorObject, ScalarTensorObject):
+    """Wrapper for `tensor(htype = 'label_class')`. Provides equality operation
+    for labeled data.
+
+    Example:
+        >>> query('labels == "dog"')
+    """
+
+    def __init__(self, tensor: Tensor) -> None:
+        super().__init__(tensor)
+
+        # FIXME tensor.info should be resolvable class
+        self._class_names = tensor.info["class_names"]  # type: ignore
+
+    def __eq__(self, o: object) -> bool:
+        if not self.is_scalar():
+            raise ValueError("Vector and scalars are not comparable")
+
+        if isinstance(o, str):
+            return self._class_names[self.as_scalar()] == o
+        else:
+            return super().__eq__(o)
+
+    def contains(self, o: object) -> bool:
+        return any(self.numpy() == o)  # type: ignore
+
+
+class EvalTextTesor(EvalTensorObject, ScalarTensorObject):
+    """Wrapper for `tensor(htype = 'text'). Provides equality operation
+    for text data.
+
+    Example:
+        >>> query('text == "some_string"')
+        >>> query('len(text) == 0')
+    """
+
+    def __init__(self, tensor) -> None:
+        super().__init__(tensor)
+
+    def contains(self, o: object) -> bool:
+        return any(self.numpy() == o)  # type: ignore
+
+    def as_scalar(self):
+        assert self.is_scalar()
+        return self.numpy()[0]
+
+    def __len__(self):
+        return len(self.as_scalar()) if self.is_scalar() else len(self.numpy())
+
+
+class EvalJsonTensor(EvalTensorObject):
+    """Wrapper for `tensor(htype = 'json'). Expose json dictionary to user
+
+    Example:
+        >>> query('json["attribute"]["nested_attribute"] == "some_value"')
+    """
+
+    def __init__(self, tensor) -> None:
+        super().__init__(tensor)
+
+    def as_scalar(self):
+        assert self.is_scalar()
+        return json.loads(self.numpy()[0])
+
+    def __getitem__(self, item):
+        return self.as_scalar()[item]
+
+
+class EvalGroupTensor(EvalObject):
+    """Wrapper around tensor groups.
+
+    Example:
+        >>> query('images.image1.mean == images.image2.mean')
+    """
+
+    def __init__(self, group) -> None:
+        super().__init__()
+        self.group = group
+        self._map: Dict[str, EvalObject] = dict()
+
+    def extend(self, name: str, tensor: Tensor):
+        if tensor.htype == "class_label":
+            self._map[name] = EvalLabelClassTensor(tensor)
+        elif tensor.htype == "text":
+            self._map[name] = EvalTextTesor(tensor)
+        elif tensor.htype == "json":
+            self._map[name] = EvalJsonTensor(tensor)
+        else:
+            self._map[name] = EvalGenericTensor(tensor)
+
+    def __getattr__(self, name):
+        return self._map[name]

--- a/hub/core/query/test/test_query.py
+++ b/hub/core/query/test/test_query.py
@@ -1,0 +1,171 @@
+import pytest
+
+import numpy as np
+
+from hub.core.query import DatasetQuery
+from hub.core.query.query import EvalGenericTensor, EvalLabelClassTensor
+
+
+first_row = {"images": [1, 2, 3], "labels": [0]}
+second_row = {"images": [6, 7, 5], "labels": [1]}
+rows = [first_row, second_row]
+class_names = ["dog", "cat", "fish"]
+
+
+@pytest.fixture
+def sample_ds(memory_ds):
+    with memory_ds as ds:
+        ds.create_tensor("images")
+        ds.create_tensor("labels", htype="class_label", class_names=class_names)
+
+        for row in rows:
+            ds.images.append(row["images"])
+            ds.labels.append(row["labels"])
+
+    return memory_ds
+
+
+def test_tensor_functions(sample_ds):
+    for ind, row in enumerate(rows):
+        i = EvalGenericTensor(sample_ds[ind].images)
+        l = EvalGenericTensor(sample_ds[ind].labels)
+
+        assert i.min == min(row["images"])
+        assert i.max == max(row["images"])
+        assert i.mean == sum(row["images"]) / len(row["images"])
+        assert i.shape[0] == len(row["images"])
+        assert i.size == len(row["images"])
+        assert i[1] == row["images"][1]
+
+        assert l == row["labels"][0]
+        assert l != row["labels"][0] + 2
+        assert l > row["labels"][0] - 1
+        assert l < row["labels"][0] + 1
+        assert l >= row["labels"][0]
+        assert l <= row["labels"][0]
+
+
+def test_class_label_tensor_function(sample_ds):
+    assert EvalLabelClassTensor(sample_ds[0].labels) == "dog"
+    assert EvalLabelClassTensor(sample_ds[1].labels) == "cat"
+
+
+def test_tensor_subscript(memory_ds):
+    arr = [[[1], [2]], [[2], [3]], [[4], [5]]]
+
+    memory_ds.create_tensor("images")
+    memory_ds.images.append(arr)
+
+    i = EvalGenericTensor(memory_ds[0].images)
+
+    assert i[2, 1] == arr[2][1]
+    assert i[1].min == min(arr[1])
+
+
+@pytest.mark.parametrize(
+    ["query", "results"],
+    [
+        ["images.max == 3", [True, False]],
+        ["images.min == 5", [False, True]],
+        ["images[:1].min == 6", [False, True]],
+        ["images[1] == 2", [True, False]],
+        ["labels == 0", [True, False]],
+        ["labels > 0 ", [False, True]],
+        ["labels in [cat, dog]", [True, True]],
+        ["labels < 0 ", [False, False]],
+        ["labels.contains(0)", [True, False]],  # weird usecase
+    ],
+)
+def test_query(sample_ds, query, results):
+    query = DatasetQuery(sample_ds, query)
+
+    for i in range(len(results)):
+        assert query(sample_ds[i]) == results[i]
+
+
+def test_query_string_tensor(memory_ds):
+    data = ["string1", "string2", ""]
+
+    with memory_ds as ds:
+        ds.create_tensor("text", htype="text")
+        for v in data:
+            ds.text.append(v)
+
+    assert DatasetQuery(memory_ds, 'text == "string1"')(memory_ds[0]) == True
+    assert DatasetQuery(memory_ds, 'text == "string1"')(memory_ds[1]) == False
+    assert DatasetQuery(memory_ds, "len(text) == 0")(memory_ds[2]) == True
+
+
+def test_query_json_tensor(memory_ds):
+    data = ['{ "a": 1 }', '{ "b": { "a": 1 }}', ""]
+
+    with memory_ds as ds:
+        ds.create_tensor("json", htype="json")
+        for v in data:
+            ds.json.append(v)
+
+    assert DatasetQuery(memory_ds, 'json["a"] == 1')(memory_ds[0]) == True
+    assert DatasetQuery(memory_ds, 'json["b"]["a"] == 1')(memory_ds[1]) == True
+
+    with pytest.raises(KeyError):
+        assert (
+            DatasetQuery(memory_ds, 'json["b"]["a"] == None')(memory_ds[0]) == True
+        )  # not sure what should happen here
+
+
+def test_query_groups(memory_ds):
+    with memory_ds as ds:
+        ds.create_tensor("images/image1")
+        ds.create_tensor("images/image2")
+
+        ds.images.image1.append([1, 2, 3])
+        ds.images.image2.append([3, 2, 1])
+
+    assert (
+        DatasetQuery(memory_ds, "images.image1.mean == images.image2.mean")(
+            memory_ds[0]
+        )
+        == True
+    )
+
+
+def test_different_size_ds_query(memory_ds):
+
+    with memory_ds as ds:
+        ds.create_tensor("images")
+        ds.create_tensor("labels")
+
+        ds.images.append([0])
+        ds.images.append([1])
+        ds.images.append([2])
+
+        ds.labels.append([0])
+        ds.labels.append([1])
+
+    result = ds.filter("labels == 0", progressbar=False)
+    assert len(result) == 1
+
+    result = ds.filter("images == 2", progressbar=False)
+    assert len(result) == 0
+
+
+def test_query_scheduler(local_ds):
+    with local_ds as ds:
+        ds.create_tensor("labels")
+        ds.labels.extend(np.arange(10_000))
+
+    def filter_result(ds):
+        return ds[0].labels.numpy()
+
+    assert (
+        filter_result(ds.filter("labels == 3141", num_workers=2, progressbar=False))
+        == 3141
+    )
+    assert (
+        filter_result(
+            ds.filter(
+                lambda s: s.labels.numpy() == 3141, num_workers=2, progressbar=False
+            )
+        )
+        == 3141
+    )

--- a/hub/core/tests/test_compute.py
+++ b/hub/core/tests/test_compute.py
@@ -1,0 +1,27 @@
+import pytest
+
+from hub.util.compute import get_compute_provider
+
+
+@pytest.mark.parametrize("scheduler", ["threaded", "processed", "ray"])
+def test_compute_with_progress_bar(scheduler):
+    def f(pg_callback, x):
+        pg_callback(1)
+        return x * 2
+
+    compute = get_compute_provider(scheduler=scheduler, num_workers=2)
+    r = compute.map_with_progressbar(f, range(1000), 1000)
+
+    assert r is not None
+    assert len(r) == 1000
+
+
+def test_serial_with_progress_bar():
+    def f(x):
+        return x * 2
+
+    compute = get_compute_provider(scheduler="serial")
+    r = compute.map_with_progressbar(f, range(1000), 1000)
+
+    assert r is not None
+    assert len(r) == 1000

--- a/hub/integrations/pytorch/common.py
+++ b/hub/integrations/pytorch/common.py
@@ -1,5 +1,4 @@
-from typing import Callable, Dict, List, Optional, Sequence
-from hub.util.exceptions import TensorDoesNotExistError
+from typing import Callable, Dict, List, Optional
 from hub.util.iterable_ordered_dict import IterableOrderedDict
 import numpy as np
 
@@ -56,19 +55,3 @@ class PytorchTransformFunction:
                 data_out[tensor] = value if fn is None else fn(value)
             return data_out
         return data_in
-
-
-def map_tensor_keys(dataset, tensor_keys: Optional[Sequence[str]] = None) -> List[str]:
-    """Sanitizes tensor_keys if not None, else returns all the keys present in the dataset."""
-
-    if tensor_keys is None:
-        tensor_keys = list(dataset.tensors)
-    else:
-        for t in tensor_keys:
-            if t not in dataset.tensors:
-                raise TensorDoesNotExistError(t)
-
-        tensor_keys = list(tensor_keys)
-
-    # Get full path in case of groups
-    return [dataset.tensors[k].key for k in tensor_keys]

--- a/hub/integrations/pytorch/pytorch.py
+++ b/hub/integrations/pytorch/pytorch.py
@@ -1,10 +1,10 @@
 from typing import Callable, Dict, Optional, Sequence, Union
 from hub.util.dataset import try_flushing
+from hub.util.dataset import map_tensor_keys
 from .common import (
     PytorchTransformFunction,
     convert_fn as default_convert_fn,
     collate_fn as default_collate_fn,
-    map_tensor_keys,
 )
 
 

--- a/hub/integrations/tests/test_pytorch_dataloader.py
+++ b/hub/integrations/tests/test_pytorch_dataloader.py
@@ -1,6 +1,5 @@
 import pytest
 import platform
-from hub.constants import MB
 from hub.util.check_installation import pytorch_installed
 
 if not pytorch_installed():
@@ -16,11 +15,8 @@ from hub.integrations.pytorch.dataset import (
     ShufflingIterableDataset,
     SubIterableDataset,
 )
-from hub.integrations.pytorch.common import (
-    collate_fn as default_collate_fn,
-    map_tensor_keys,
-)
-
+from hub.integrations.pytorch.common import collate_fn as default_collate_fn
+from hub.util.dataset import map_tensor_keys
 import torch
 from torch.utils.data.dataloader import DataLoader
 import numpy

--- a/hub/util/dataset.py
+++ b/hub/util/dataset.py
@@ -1,4 +1,5 @@
-from hub.util.exceptions import ReadOnlyModeError
+from typing import Optional, Sequence, List
+from hub.util.exceptions import ReadOnlyModeError, TensorDoesNotExistError
 
 
 def try_flushing(ds):
@@ -6,3 +7,19 @@ def try_flushing(ds):
         ds.flush()
     except ReadOnlyModeError:
         pass
+
+
+def map_tensor_keys(dataset, tensor_keys: Optional[Sequence[str]] = None) -> List[str]:
+    """Sanitizes tensor_keys if not None, else returns all the keys present in the dataset."""
+
+    if tensor_keys is None:
+        tensor_keys = list(dataset.tensors)
+    else:
+        for t in tensor_keys:
+            if t not in dataset.tensors:
+                raise TensorDoesNotExistError(t)
+
+        tensor_keys = list(tensor_keys)
+
+    # Get full path in case of groups
+    return [dataset.tensors[k].key for k in tensor_keys]


### PR DESCRIPTION
Allows to execute filter query on the dataset using functions

```python
ds.filter(lambda sample: sample.labels.numpy() == 2)
```

Or using simple query language:

```python
ds.filter('lables == 2')
```

Query language have following limitations:
* Scalar types are allowed: integers, float, boolean, strings
* Operations on the tensors that are result to a scalar _min_, _max_, _mean_, _shape_, _size_
* Tensor to scalar comparison is allowed, if and only if, tensor is size of 1, which can be mapped to the scalar. 