### PR TITLE
Query to cache whole numpy array if it is data-cachable

### DIFF
--- a/hub/core/query/filter.py
+++ b/hub/core/query/filter.py
@@ -48,9 +48,9 @@ def filter_with_compute(
     def pg_filter_slice(pg_callback, indices: Sequence[int]):
         result = list()
         for i in indices:
-            pg_callback(1)
             if filter_function(dataset[i]):
                 result.append(i)
+            pg_callback(1)
 
         return result
 

--- a/hub/core/query/query.py
+++ b/hub/core/query/query.py
@@ -28,15 +28,15 @@ class DatasetQuery:
         self._dataset = dataset
         self._query = query
         self.global_vars: Dict[str, Any] = dict()
-        self.cache = dict()
-        self.locals = self._export_tensors(dataset)
+        self.cache: Dict[str, np.ndarray] = dict()
+        self.locals: Dict[str, Any] = self._export_tensors(dataset)
         self.index: Index = Index()
 
     def __call__(self, *args: Any) -> bool:
         return self._call_eval(*args)
 
     def _call_eval(self, sample_in: hub.Dataset):
-        self.index = sample_in.index
+        self.index = sample_in.index  # type: ignore
 
         return eval(
             self._query, self.global_vars, self.locals
@@ -59,7 +59,7 @@ class DatasetQuery:
 
                 if not group in bindings:
                     bindings[group] = EvalGroupTensor(self, group)
-                bindings[group].extend(tensor_name, tensor)
+                bindings[group].extend(tensor_name, tensor)  # type: ignore
 
             else:
                 bindings[key] = EvalGenericTensor(self, tensor)

--- a/hub/core/query/test/test_query.py
+++ b/hub/core/query/test/test_query.py
@@ -27,8 +27,8 @@ def sample_ds(memory_ds):
 
 def test_tensor_functions(sample_ds):
     for ind, row in enumerate(rows):
-        i = EvalGenericTensor(sample_ds[ind].images)
-        l = EvalGenericTensor(sample_ds[ind].labels)
+        i = EvalGenericTensor(DatasetQuery(sample_ds[ind], ""), sample_ds[ind].images)
+        l = EvalGenericTensor(DatasetQuery(sample_ds[ind], ""), sample_ds[ind].labels)
 
         assert i.min == min(row["images"])
         assert i.max == max(row["images"])
@@ -46,8 +46,14 @@ def test_tensor_functions(sample_ds):
 
 
 def test_class_label_tensor_function(sample_ds):
-    assert EvalLabelClassTensor(sample_ds[0].labels) == "dog"
-    assert EvalLabelClassTensor(sample_ds[1].labels) == "cat"
+    assert (
+        EvalLabelClassTensor(DatasetQuery(sample_ds[0], ""), sample_ds[0].labels)
+        == "dog"
+    )
+    assert (
+        EvalLabelClassTensor(DatasetQuery(sample_ds[1], ""), sample_ds[1].labels)
+        == "cat"
+    )
 
 
 def test_tensor_subscript(memory_ds):
@@ -56,10 +62,10 @@ def test_tensor_subscript(memory_ds):
     memory_ds.create_tensor("images")
     memory_ds.images.append(arr)
 
-    i = EvalGenericTensor(memory_ds[0].images)
+    i = EvalGenericTensor(DatasetQuery(memory_ds[0], ""), memory_ds[0].images)
 
     assert i[2, 1] == arr[2][1]
-    assert i[1].min == min(arr[1])
+    assert i[1].min == min(arr[1])[0]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Query optimizations:

```
>>> import hub
>>> ds = hub.load("hub://activeloop/imagenet-train")
Opening dataset in read-only mode as you don't have write permissions.
hub://activeloop/imagenet-train loaded successfully.
This dataset can be visualized at https://app.activeloop.ai/activeloop/imagenet-train.
>>> t = ds.filter('labels == 1')
100%|███████████████████████████████████████████████████████████████████████████████████████████| 1281166/1281166 [00:29<00:00, 43715.36it/s]
```