### PR TITLE
Compresses Diff format and fix diff bug in Transforms

### DIFF
--- a/hub/core/chunk_engine.py
+++ b/hub/core/chunk_engine.py
@@ -381,7 +381,7 @@ class ChunkEngine:
                 if sample.is_last_write:
                     self.tile_encoder.register_sample(sample, self.num_samples - 1)
                     samples = samples[1:]
-                    commit_diff.add(1)
+                    commit_diff.add_data(1)
                 if len(samples) > 0:
                     current_chunk = self._create_new_chunk()
                     updated_chunks.add(current_chunk)

--- a/hub/core/dataset/dataset.py
+++ b/hub/core/dataset/dataset.py
@@ -43,7 +43,6 @@ from hub.util.path import get_path_from_storage
 from hub.util.remove_cache import get_base_storage
 from hub.util.diff import (
     compare_commits,
-    create_changes_dict,
     get_all_changes_string,
     filter_data_updated,
     get_changes_for_id,
@@ -491,7 +490,7 @@ class Dataset:
         message1 = message2 = changes1 = changes2 = None
 
         if id_1 is None and id_2 is None:
-            changes1 = create_changes_dict()
+            changes1 = defaultdict(dict)
             commit_id = version_state["commit_id"]
             get_changes_for_id(commit_id, storage, changes1)
             filter_data_updated(changes1)

--- a/hub/core/dataset/dataset.py
+++ b/hub/core/dataset/dataset.py
@@ -477,9 +477,9 @@ class Dataset:
 
             Example of a dict returned:
             {
-                "image": {"data_added": [3, 6], "data_updated": {0, 2}, "created": False},
-                "label": {"data_added": [0, 3], "data_updated": {}, "created": True},
-                "other/stuff" : {data_added: [3, 3], data_updated: {1, 2}, created: True}
+                "image": {"data_added": [3, 6], "data_updated": {0, 2}, "created": False, "info_updated": False, "data_transformed_in_place": False},
+                "label": {"data_added": [0, 3], "data_updated": {}, "created": True, "info_updated": False, "data_transformed_in_place": False},
+                "other/stuff" : {data_added: [3, 3], data_updated: {1, 2}, created: True, "info_updated": False, "data_transformed_in_place": False}
             }
 
             Here the data_adeded is a range of sample indexes that were added to the tensor.
@@ -488,6 +488,12 @@ class Dataset:
 
             data_updated on the other hand is a set of sample indexes that were updated.
             For example {0, 2} means that sample 0 and 2 were updated.
+
+            created is a boolean that is True if the tensor was created.
+
+            info_updated is a boolean that is True if the info of the tensor was updated.
+
+            data_transformed_in_place is a boolean that is True if the data of the tensor was transformed in place.
 
 
         Raises:

--- a/hub/core/dataset/dataset.py
+++ b/hub/core/dataset/dataset.py
@@ -487,14 +487,13 @@ class Dataset:
             ValueError: If both id_1 is None and id_2 is not None.
         """
         version_state, storage = self.version_state, self.storage
-        message1 = message2 = changes1 = changes2 = None
-
         if id_1 is None and id_2 is None:
-            changes1 = defaultdict(dict)
+            changes1: Dict[str, Dict] = defaultdict(dict)
             commit_id = version_state["commit_id"]
             get_changes_for_id(commit_id, storage, changes1)
             filter_data_updated(changes1)
             message1 = f"Diff in {commit_id} (current commit):\n"
+            message2 = changes2 = None
         else:
             if id_1 is None:
                 raise ValueError("Can't specify id_1 without specifying id_2")

--- a/hub/core/dataset/dataset.py
+++ b/hub/core/dataset/dataset.py
@@ -477,10 +477,17 @@ class Dataset:
 
             Example of a dict returned:
             {
-                "image": {"data_added": {3, 4, 5}, "data_updated": {0, 2}, "created": False},
-                "label": {"data_added": {0, 1, 2}, "data_updated": {}, "created": True},
-                "other/stuff" : {data_added: {2, 3}, data_updated: {1,2}, created: True}
+                "image": {"data_added": [3, 6], "data_updated": {0, 2}, "created": False},
+                "label": {"data_added": [0, 3], "data_updated": {}, "created": True},
+                "other/stuff" : {data_added: [3, 3], data_updated: {1, 2}, created: True}
             }
+
+            Here the data_adeded is a range of sample indexes that were added to the tensor.
+            For example [3, 6] means that sample 3, 4 and 5 were added.
+            Another example [3, 3] means that no samples were added as the range is empty
+
+            data_updated on the other hand is a set of sample indexes that were updated.
+            For example {0, 2} means that sample 0 and 2 were updated.
 
 
         Raises:

--- a/hub/core/meta/encode/chunk_id.py
+++ b/hub/core/meta/encode/chunk_id.py
@@ -137,7 +137,7 @@ class ChunkIdEncoder(Encoder, Cachable):
                 f"Cannot register negative num samples. Got: {num_samples}"
             )
 
-        if self.num_samples == 0:
+        if len(self.array) == 0:
             raise ChunkIdEncoderError(
                 "Cannot register samples because no chunk IDs exist."
             )

--- a/hub/core/transform/test_transform.py
+++ b/hub/core/transform/test_transform.py
@@ -35,6 +35,7 @@ all_compressions = pytest.mark.parametrize("sample_compression", [None, "png", "
 schedulers = ["threaded", "processed"]
 schedulers = schedulers + ["ray"] if ray_installed() else schedulers
 all_schedulers = pytest.mark.parametrize("scheduler", schedulers)
+commit_or_not = pytest.mark.parametrize("do_commit", [True, False])
 
 
 @hub.compute
@@ -245,24 +246,12 @@ def test_chain_transform_list_small(ds, scheduler):
 
 
 @all_schedulers
-@enabled_non_gcs_datasets
-@pytest.mark.xfail(raises=TransformError, strict=False)
-def test_chain_transform_list_big(ds, scheduler):
+def test_chain_transform_list_big(local_ds, scheduler):
     ls = [i for i in range(2)]
-    ds_out = ds
+    ds_out = local_ds
     ds_out.create_tensor("image")
     ds_out.create_tensor("label")
     pipeline = hub.compose([fn3(mul=5, copy=2), fn2(mul=3, copy=3)])
-    if (
-        isinstance(remove_memory_cache(ds.storage), MemoryProvider)
-        and scheduler != "threaded"
-    ):
-        # any scheduler other than `threaded` will not work with a dataset stored in memory
-        with pytest.raises(InvalidOutputDatasetError):
-            pipeline.eval(
-                ls, ds_out, num_workers=TRANSFORM_TEST_NUM_WORKERS, scheduler=scheduler
-            )
-        return
     pipeline.eval(
         ls, ds_out, num_workers=TRANSFORM_TEST_NUM_WORKERS, scheduler=scheduler
     )
@@ -275,6 +264,63 @@ def test_chain_transform_list_big(ds, scheduler):
             np.testing.assert_array_equal(
                 ds_out[index].label.numpy(), 15 * i * np.ones((13,))
             )
+
+
+@all_schedulers
+@commit_or_not
+def test_add_to_non_empty_dataset(local_ds, scheduler, do_commit):
+    ls = [i for i in range(100)]
+    ds_out = local_ds
+    ds_out.create_tensor("image")
+    ds_out.create_tensor("label")
+    pipeline = hub.compose([fn1(mul=5, copy=2), fn2(mul=3, copy=3)])
+    with ds_out:
+        for i in range(10):
+            ds_out.image.append(i * np.ones((10, 10)))
+            ds_out.label.append(i * np.ones((1,)))
+        if do_commit:
+            ds_out.commit()
+
+    pipeline.eval(
+        ls, ds_out, num_workers=TRANSFORM_TEST_NUM_WORKERS, scheduler=scheduler
+    )
+    assert len(ds_out) == 610
+    for i in range(10):
+        np.testing.assert_array_equal(ds_out[i].image.numpy(), i * np.ones((10, 10)))
+        np.testing.assert_array_equal(ds_out[i].label.numpy(), i * np.ones((1,)))
+    for i in range(100):
+        for index in range(10 + 6 * i, 10 + 6 * i + 6):
+            np.testing.assert_array_equal(
+                ds_out[index].image.numpy(), 15 * i * np.ones((337, 200))
+            )
+            np.testing.assert_array_equal(
+                ds_out[index].label.numpy(), 15 * i * np.ones((1,))
+            )
+
+    diff = ds_out.diff(as_dict=True)
+    change = {
+        "image": {
+            "data_updated": set(),
+            "info_updated": False,
+            "data_transformed_in_place": False,
+        },
+        "label": {
+            "data_updated": set(),
+            "info_updated": False,
+            "data_transformed_in_place": False,
+        },
+    }
+    if do_commit:
+        change["image"]["created"] = False
+        change["label"]["created"] = False
+        change["image"]["data_added"] = [10, 610]
+        change["label"]["data_added"] = [10, 610]
+    else:
+        change["image"]["created"] = True
+        change["label"]["created"] = True
+        change["image"]["data_added"] = [0, 610]
+        change["label"]["data_added"] = [0, 610]
+    assert diff == change
 
 
 @all_schedulers
@@ -474,13 +520,19 @@ def test_inplace_transform(local_ds_generator):
     with ds:
         ds.create_tensor("img")
         ds.create_tensor("label")
-        for _ in range(100):
-            ds.img.append(np.ones((500, 500, 3)))
+        for i in range(100):
+            if i == 55:
+                ds.img.append(np.zeros((500, 500, 3)))
+            else:
+                ds.img.append(np.ones((500, 500, 3)))
             ds.label.append(np.ones((100, 100, 3)))
         a = ds.commit()
         assert len(ds) == 100
         for i in range(100):
-            check_target_array(ds, i, 1)
+            if i != 55:
+                check_target_array(ds, i, 1)
+        ds.img[55] = np.ones((500, 500, 3))
+        b = ds.commit()
 
         inplace_transform().eval(ds, num_workers=TRANSFORM_TEST_NUM_WORKERS)
         assert ds.img.chunk_engine.num_samples == len(ds) == 200
@@ -489,7 +541,26 @@ def test_inplace_transform(local_ds_generator):
             target = 2 if i % 2 == 0 else 3
             check_target_array(ds, i, target)
 
-        ds.checkout(a)
+        diff = ds.diff(as_dict=True)
+        change = {
+            "img": {
+                "created": False,
+                "data_added": [0, 200],
+                "data_updated": set(),
+                "data_transformed_in_place": True,
+                "info_updated": False,
+            },
+            "label": {
+                "created": False,
+                "data_added": [0, 200],
+                "data_updated": set(),
+                "data_transformed_in_place": True,
+                "info_updated": False,
+            },
+        }
+        assert diff == change
+
+        ds.checkout(b)
         assert len(ds) == 100
         for i in range(100):
             check_target_array(ds, i, 1)
@@ -500,7 +571,7 @@ def test_inplace_transform(local_ds_generator):
         target = 2 if i % 2 == 0 else 3
         check_target_array(ds, i, target)
 
-    ds.checkout(a)
+    ds.checkout(b)
     assert len(ds) == 100
     for i in range(100):
         check_target_array(ds, i, 1)

--- a/hub/core/transform/transform.py
+++ b/hub/core/transform/transform.py
@@ -17,6 +17,7 @@ from hub.util.transform import (
 )
 from hub.util.encoder import (
     merge_all_chunk_id_encoders,
+    merge_all_commit_diffs,
     merge_all_tensor_metas,
     merge_all_tile_encoders,
     merge_all_commit_chunk_sets,
@@ -248,6 +249,7 @@ class Pipeline:
             all_chunk_id_encoders,
             all_tile_encoders,
             all_chunk_commit_sets,
+            all_commit_diffs,
         ) = zip(*metas_and_encoders)
         all_num_samples = []
         for tensor_meta_dict in all_tensor_metas:
@@ -260,6 +262,7 @@ class Pipeline:
         merge_all_chunk_id_encoders(
             all_chunk_id_encoders, target_ds, storage, overwrite
         )
+        merge_all_commit_diffs(all_commit_diffs, target_ds, storage, overwrite)
         if target_ds.commit_id != FIRST_COMMIT_ID:
             merge_all_commit_chunk_sets(
                 all_chunk_commit_sets, target_ds, storage, overwrite

--- a/hub/core/transform/transform.py
+++ b/hub/core/transform/transform.py
@@ -255,6 +255,7 @@ class Pipeline:
         for tensor_meta_dict in all_tensor_metas:
             num_samples_dict = {k: v.length for k, v in tensor_meta_dict.items()}
             all_num_samples.append(num_samples_dict)
+        merge_all_commit_diffs(all_commit_diffs, target_ds, storage, overwrite)
         merge_all_tile_encoders(
             all_tile_encoders, all_num_samples, target_ds, storage, overwrite
         )
@@ -262,7 +263,6 @@ class Pipeline:
         merge_all_chunk_id_encoders(
             all_chunk_id_encoders, target_ds, storage, overwrite
         )
-        merge_all_commit_diffs(all_commit_diffs, target_ds, storage, overwrite)
         if target_ds.commit_id != FIRST_COMMIT_ID:
             merge_all_commit_chunk_sets(
                 all_chunk_commit_sets, target_ds, storage, overwrite

--- a/hub/core/version_control/commit_diff.py
+++ b/hub/core/version_control/commit_diff.py
@@ -9,19 +9,22 @@ class CommitDiff(Cachable):
         self.created = created
         self.data_added: List[int] = [first_index, first_index]
         self.data_updated: Set[int] = set()
+        self.info_updated = False
 
     def tobytes(self) -> bytes:
         """Returns bytes representation of the commit diff
 
         The format stores the following information in order:
         1. The first byte is a boolean value indicating whether the tensor was created in the commit or not.
-        2. The next 8 + 8 bytes are the two elements of the data_added list.
-        3. The next 8 bytes are the number of elements in the data_updated set, let's call this m.
-        4. The next 8 * m bytes are the elements of the data_updated set.
+        2. The second byte is a boolean value indicating whether the info has been updated or not.
+        3. The next 8 + 8 bytes are the two elements of the data_added list.
+        4. The next 8 bytes are the number of elements in the data_updated set, let's call this m.
+        5. The next 8 * m bytes are the elements of the data_updated set.
         """
         return b"".join(
             [
                 self.created.to_bytes(1, "big"),
+                self.info_updated.to_bytes(1, "big"),
                 self.data_added[0].to_bytes(8, "big"),
                 self.data_added[1].to_bytes(8, "big"),
                 len(self.data_updated).to_bytes(8, "big"),
@@ -35,13 +38,14 @@ class CommitDiff(Cachable):
         commit_diff = cls()
 
         commit_diff.created = bool(int.from_bytes(data[:1], "big"))
+        commit_diff.info_updated = bool(int.from_bytes(data[1:2], "big"))
         commit_diff.data_added = [
-            int.from_bytes(data[1:9], "big"),
-            int.from_bytes(data[9:17], "big"),
+            int.from_bytes(data[2:10], "big"),
+            int.from_bytes(data[10:18], "big"),
         ]
-        num_updates = int.from_bytes(data[17:25], "big")
+        num_updates = int.from_bytes(data[18:26], "big")
         commit_diff.data_updated = {
-            int.from_bytes(data[25 + i * 8 : 33 + i * 8], "big")
+            int.from_bytes(data[26 + i * 8 : 34 + i * 8], "big")
             for i in range(num_updates)
         }
 
@@ -50,16 +54,20 @@ class CommitDiff(Cachable):
     @property
     def nbytes(self):
         """Returns number of bytes required to store the commit diff"""
-        return 25 + 8 * len(self.data_updated)
-
-    def add_data(self, count: int) -> None:
-        """Adds new indexes to data added"""
-        self.data_added[1] += count
+        return 26 + 8 * len(self.data_updated)
 
     @property
     def num_samples_added(self) -> int:
         """Returns number of samples added"""
         return self.data_added[1] - self.data_added[0]
+
+    def modify_info(self) -> None:
+        """Stores information that the info has changed"""
+        self.info_updated = True
+
+    def add_data(self, count: int) -> None:
+        """Adds new indexes to data added"""
+        self.data_added[1] += count
 
     def update_data(self, global_index: int) -> None:
         """Adds new indexes to data updated"""

--- a/hub/core/version_control/commit_diff.py
+++ b/hub/core/version_control/commit_diff.py
@@ -1,13 +1,13 @@
-from typing import Set
+from typing import Set, List
 from hub.core.storage.cachable import Cachable
 
 
 class CommitDiff(Cachable):
     """Stores set of diffs stored for a particular tensor in a commit."""
 
-    def __init__(self, created=False) -> None:
+    def __init__(self, first_index=0, created=False) -> None:
         self.created = created
-        self.data_added: Set[int] = set()
+        self.data_added: List[int] = [first_index, first_index]
         self.data_updated: Set[int] = set()
 
     def tobytes(self) -> bytes:
@@ -15,18 +15,17 @@ class CommitDiff(Cachable):
 
         The format stores the following information in order:
         1. The first byte is a boolean value indicating whether the tensor was created in the commit or not.
-        2. The next 8 bytes are the number of elements in the data_added set, let's call this n.
-        3. The next 8 * n bytes are the elements of the data_added set.
-        4. The next 8 bytes are the number of elements in the data_updated set, let's call this m.
-        5. The next 8 * m bytes are the elements of the data_updated set.
+        2. The next 8 + 8 bytes are the two elements of the data_added list.
+        3. The next 8 bytes are the number of elements in the data_updated set, let's call this m.
+        4. The next 8 * m bytes are the elements of the data_updated set.
         """
         return b"".join(
             [
                 self.created.to_bytes(1, "big"),
-                len(self.data_added).to_bytes(8, "big"),
-                *[idx.to_bytes(8, "big") for idx in self.data_added],
+                self.data_added[0].to_bytes(8, "big"),
+                self.data_added[1].to_bytes(8, "big"),
                 len(self.data_updated).to_bytes(8, "big"),
-                *[idx.to_bytes(8, "big") for idx in self.data_updated],
+                *(idx.to_bytes(8, "big") for idx in self.data_updated),
             ]
         )
 
@@ -35,19 +34,15 @@ class CommitDiff(Cachable):
         """Creates a CommitDiff object from bytes"""
         commit_diff = cls()
 
-        commit_diff.created = bool(int.from_bytes(data[0:1], "big"))
-
-        added_ct = int.from_bytes(data[1:9], "big")
-        commit_diff.data_added = {
-            int.from_bytes(data[9 + i * 8 : 9 + (i + 1) * 8], "big")
-            for i in range(added_ct)
-        }
-
-        updated_ct = int.from_bytes(data[9 + added_ct * 8 : 17 + added_ct * 8], "big")
-        offset = 17 + added_ct * 8
+        commit_diff.created = bool(int.from_bytes(data[:1], "big"))
+        commit_diff.data_added = [
+            int.from_bytes(data[1:9], "big"),
+            int.from_bytes(data[9:17], "big"),
+        ]
+        num_updates = int.from_bytes(data[17:25], "big")
         commit_diff.data_updated = {
-            int.from_bytes(data[offset + i * 8 : offset + (i + 1) * 8], "big")
-            for i in range(updated_ct)
+            int.from_bytes(data[25 + i * 8 : 33 + i * 8], "big")
+            for i in range(num_updates)
         }
 
         return commit_diff
@@ -55,21 +50,18 @@ class CommitDiff(Cachable):
     @property
     def nbytes(self):
         """Returns number of bytes required to store the commit diff"""
-        return 17 + (len(self.data_added) + len(self.data_updated)) * 8
+        return 25 + 8 * len(self.data_updated)
 
-    def add_data(self, global_indexes: Set[int]) -> None:
+    def add_data(self, count: int) -> None:
         """Adds new indexes to data added"""
-        self.data_added.update(global_indexes)
+        self.data_added[1] += count
+
+    @property
+    def num_samples_added(self) -> int:
+        """Returns number of samples added"""
+        return self.data_added[1] - self.data_added[0]
 
     def update_data(self, global_index: int) -> None:
         """Adds new indexes to data updated"""
         if global_index not in self.data_added:
             self.data_updated.add(global_index)
-
-
-def get_sample_indexes_added(initial_num_samples: int, samples) -> Set[int]:
-    """Returns a set of indexes added to the tensor"""
-    if initial_num_samples == 0:
-        return set(range(len(samples)))
-    else:
-        return set(range(initial_num_samples, initial_num_samples + len(samples)))

--- a/hub/core/version_control/test_version_control.py
+++ b/hub/core/version_control/test_version_control.py
@@ -386,9 +386,9 @@ def test_diff_linear(local_ds, capsys):
 
     local_ds.diff()
     changes_b_from_a = {
-        "xyz": {"data_added": set(), "data_updated": {0}, "created": False},
-        "pqr": {"data_added": set(), "data_updated": {2}, "created": False},
-        "abc": {"data_added": {0, 1, 2}, "data_updated": set(), "created": True},
+        "xyz": {"data_added": [3, 3], "data_updated": {0}, "created": False},
+        "pqr": {"data_added": [3, 3], "data_updated": {2}, "created": False},
+        "abc": {"data_added": [0, 3], "data_updated": set(), "created": True},
     }
     message1 = f"Diff in {local_ds.commit_id} (current commit):\n"
     target = get_all_changes_string(changes_b_from_a, message1, None, None) + "\n"
@@ -488,11 +488,11 @@ def test_diff_branch(local_ds, capsys):
 
     local_ds.diff()
     changes_b_from_branch_off = {
-        "xyz": {"data_added": {3, 4, 5}, "data_updated": {2}, "created": False},
-        "pqr": {"data_added": {0, 1, 2}, "data_updated": set(), "created": True},
+        "xyz": {"data_added": [3, 6], "data_updated": {2}, "created": False},
+        "pqr": {"data_added": [0, 3], "data_updated": set(), "created": True},
     }
     changes_main_from_branch_off = {
-        "xyz": {"data_added": {3, 4}, "data_updated": {0, 2}, "created": False},
+        "xyz": {"data_added": [3, 5], "data_updated": {0, 2}, "created": False},
     }
     message1 = f"Diff in {local_ds.commit_id} (current commit):\n"
     target = (
@@ -682,12 +682,12 @@ def test_complex_diff(local_ds, capsys):
 
     # x is LCA of a and g
     changes_c_from_x = {
-        "xyz": {"data_added": {3, 4, 5}, "data_updated": {0}, "created": False},
+        "xyz": {"data_added": [3, 6], "data_updated": {0}, "created": False},
     }
     changes_g_from_x = {
-        "pqr": {"data_added": {0}, "data_updated": set(), "created": True},
-        "tuv": {"data_added": {0, 1, 2}, "data_updated": set(), "created": True},
-        "xyz": {"data_added": set(), "data_updated": {1}, "created": False},
+        "pqr": {"data_added": [0, 1], "data_updated": set(), "created": True},
+        "tuv": {"data_added": [0, 3], "data_updated": set(), "created": True},
+        "xyz": {"data_added": [3, 3], "data_updated": {1}, "created": False},
     }
     empty_changes = {}
 
@@ -732,8 +732,8 @@ def test_complex_diff(local_ds, capsys):
     assert diff[1] == empty_changes
 
     changes_main_from_x = {
-        "xyz": {"data_added": set(), "data_updated": {1}, "created": False},
-        "pqr": {"data_added": set(), "data_updated": set(), "created": True},
+        "xyz": {"data_added": [3, 3], "data_updated": {1}, "created": False},
+        "pqr": {"data_added": [0, 0], "data_updated": set(), "created": True},
     }
 
     local_ds.diff(c, "main")

--- a/hub/core/version_control/test_version_control.py
+++ b/hub/core/version_control/test_version_control.py
@@ -391,18 +391,21 @@ def test_diff_linear(local_ds, capsys):
             "data_updated": {0},
             "created": False,
             "info_updated": False,
+            "data_transformed_in_place": False,
         },
         "pqr": {
             "data_added": [3, 3],
             "data_updated": {2},
             "created": False,
             "info_updated": False,
+            "data_transformed_in_place": False,
         },
         "abc": {
             "data_added": [0, 3],
             "data_updated": set(),
             "created": True,
             "info_updated": False,
+            "data_transformed_in_place": False,
         },
     }
     message1 = f"Diff in {local_ds.commit_id} (current commit):\n"
@@ -508,12 +511,14 @@ def test_diff_branch(local_ds, capsys):
             "data_updated": {2},
             "created": False,
             "info_updated": False,
+            "data_transformed_in_place": False,
         },
         "pqr": {
             "data_added": [0, 3],
             "data_updated": set(),
             "created": True,
             "info_updated": False,
+            "data_transformed_in_place": False,
         },
     }
     changes_main_from_branch_off = {
@@ -522,6 +527,7 @@ def test_diff_branch(local_ds, capsys):
             "data_updated": {0, 2},
             "created": False,
             "info_updated": False,
+            "data_transformed_in_place": False,
         },
     }
     message1 = f"Diff in {local_ds.commit_id} (current commit):\n"
@@ -717,6 +723,7 @@ def test_complex_diff(local_ds, capsys):
             "data_updated": {0},
             "created": False,
             "info_updated": False,
+            "data_transformed_in_place": False,
         },
     }
     changes_g_from_x = {
@@ -725,18 +732,21 @@ def test_complex_diff(local_ds, capsys):
             "data_updated": set(),
             "created": True,
             "info_updated": False,
+            "data_transformed_in_place": False,
         },
         "tuv": {
             "data_added": [0, 3],
             "data_updated": set(),
             "created": True,
             "info_updated": False,
+            "data_transformed_in_place": False,
         },
         "xyz": {
             "data_added": [3, 3],
             "data_updated": {1},
             "created": False,
             "info_updated": False,
+            "data_transformed_in_place": False,
         },
     }
     empty_changes = {}
@@ -787,12 +797,14 @@ def test_complex_diff(local_ds, capsys):
             "data_updated": {1},
             "created": False,
             "info_updated": False,
+            "data_transformed_in_place": False,
         },
         "pqr": {
             "data_added": [0, 0],
             "data_updated": set(),
             "created": True,
             "info_updated": False,
+            "data_transformed_in_place": False,
         },
     }
 

--- a/hub/core/version_control/test_version_control.py
+++ b/hub/core/version_control/test_version_control.py
@@ -386,9 +386,24 @@ def test_diff_linear(local_ds, capsys):
 
     local_ds.diff()
     changes_b_from_a = {
-        "xyz": {"data_added": [3, 3], "data_updated": {0}, "created": False},
-        "pqr": {"data_added": [3, 3], "data_updated": {2}, "created": False},
-        "abc": {"data_added": [0, 3], "data_updated": set(), "created": True},
+        "xyz": {
+            "data_added": [3, 3],
+            "data_updated": {0},
+            "created": False,
+            "info_updated": False,
+        },
+        "pqr": {
+            "data_added": [3, 3],
+            "data_updated": {2},
+            "created": False,
+            "info_updated": False,
+        },
+        "abc": {
+            "data_added": [0, 3],
+            "data_updated": set(),
+            "created": True,
+            "info_updated": False,
+        },
     }
     message1 = f"Diff in {local_ds.commit_id} (current commit):\n"
     target = get_all_changes_string(changes_b_from_a, message1, None, None) + "\n"
@@ -488,11 +503,26 @@ def test_diff_branch(local_ds, capsys):
 
     local_ds.diff()
     changes_b_from_branch_off = {
-        "xyz": {"data_added": [3, 6], "data_updated": {2}, "created": False},
-        "pqr": {"data_added": [0, 3], "data_updated": set(), "created": True},
+        "xyz": {
+            "data_added": [3, 6],
+            "data_updated": {2},
+            "created": False,
+            "info_updated": False,
+        },
+        "pqr": {
+            "data_added": [0, 3],
+            "data_updated": set(),
+            "created": True,
+            "info_updated": False,
+        },
     }
     changes_main_from_branch_off = {
-        "xyz": {"data_added": [3, 5], "data_updated": {0, 2}, "created": False},
+        "xyz": {
+            "data_added": [3, 5],
+            "data_updated": {0, 2},
+            "created": False,
+            "info_updated": False,
+        },
     }
     message1 = f"Diff in {local_ds.commit_id} (current commit):\n"
     target = (
@@ -682,12 +712,32 @@ def test_complex_diff(local_ds, capsys):
 
     # x is LCA of a and g
     changes_c_from_x = {
-        "xyz": {"data_added": [3, 6], "data_updated": {0}, "created": False},
+        "xyz": {
+            "data_added": [3, 6],
+            "data_updated": {0},
+            "created": False,
+            "info_updated": False,
+        },
     }
     changes_g_from_x = {
-        "pqr": {"data_added": [0, 1], "data_updated": set(), "created": True},
-        "tuv": {"data_added": [0, 3], "data_updated": set(), "created": True},
-        "xyz": {"data_added": [3, 3], "data_updated": {1}, "created": False},
+        "pqr": {
+            "data_added": [0, 1],
+            "data_updated": set(),
+            "created": True,
+            "info_updated": False,
+        },
+        "tuv": {
+            "data_added": [0, 3],
+            "data_updated": set(),
+            "created": True,
+            "info_updated": False,
+        },
+        "xyz": {
+            "data_added": [3, 3],
+            "data_updated": {1},
+            "created": False,
+            "info_updated": False,
+        },
     }
     empty_changes = {}
 
@@ -732,8 +782,18 @@ def test_complex_diff(local_ds, capsys):
     assert diff[1] == empty_changes
 
     changes_main_from_x = {
-        "xyz": {"data_added": [3, 3], "data_updated": {1}, "created": False},
-        "pqr": {"data_added": [0, 0], "data_updated": set(), "created": True},
+        "xyz": {
+            "data_added": [3, 3],
+            "data_updated": {1},
+            "created": False,
+            "info_updated": False,
+        },
+        "pqr": {
+            "data_added": [0, 0],
+            "data_updated": set(),
+            "created": True,
+            "info_updated": False,
+        },
     }
 
     local_ds.diff(c, "main")

--- a/hub/util/diff.py
+++ b/hub/util/diff.py
@@ -136,6 +136,15 @@ def get_changes_for_id(commit_id: str, storage: LRUCache, changes: Dict[str, Dic
             commit_diff: CommitDiff = storage.get_cachable(commit_diff_key, CommitDiff)
             change = changes[tensor]
 
+            change["created"] = change.get("created") or commit_diff.created
+            change["info_updated"] = (
+                change.get("info_updated") or commit_diff.info_updated
+            )
+
+            # this means that the data was transformed inplace in a newer commit, so we can ignore older diffs
+            if change.get("data_transformed_in_place", False):
+                continue
+
             if "data_added" not in change:
                 change["data_added"] = commit_diff.data_added.copy()
             else:
@@ -145,10 +154,8 @@ def get_changes_for_id(commit_id: str, storage: LRUCache, changes: Dict[str, Dic
                 change["data_updated"] = commit_diff.data_updated.copy()
             else:
                 change["data_updated"].update(commit_diff.data_updated)
-
-            change["created"] = change.get("created") or commit_diff.created
-            change["info_updated"] = (
-                change.get("info_updated") or commit_diff.info_updated
+            change["data_transformed_in_place"] = (
+                change.get("data_transformed_in_place") or commit_diff.data_transformed
             )
         except KeyError:
             pass

--- a/hub/util/diff.py
+++ b/hub/util/diff.py
@@ -28,8 +28,8 @@ def compare_commits(
     lca_id = get_lowest_common_ancestor(commit_node_1, commit_node_2)
     lca = version_state["commit_node_map"][lca_id]
 
-    changes_1 = defaultdict(dict)
-    changes_2 = defaultdict(dict)
+    changes_1: Dict[str, Dict] = defaultdict(dict)
+    changes_2: Dict[str, Dict] = defaultdict(dict)
 
     for commit_node, changes in [
         (commit_node_1, changes_1),
@@ -136,7 +136,7 @@ def get_changes_for_id(commit_id: str, storage: LRUCache, changes: Dict[str, Dic
                 change["data_updated"] = commit_diff.data_updated.copy()
             else:
                 change["data_updated"].update(commit_diff.data_updated)
-        
+
             change["created"] = change.get("created") or commit_diff.created
         except KeyError:
             pass
@@ -149,6 +149,7 @@ def filter_data_updated(changes: Dict[str, Dict]):
         data_added_range = range(change["data_added"][0], change["data_added"][1] + 1)
         upd = {data for data in change["data_updated"] if data not in data_added_range}
         change["data_updated"] = upd
+
 
 def compress_into_range_intervals(indexes: Set[int]) -> List[Tuple[int, int]]:
     """Compresses the indexes into range intervals.

--- a/hub/util/diff.py
+++ b/hub/util/diff.py
@@ -95,20 +95,20 @@ def get_changes_str(changes: Dict, message: str, separator: str):
     all_changes = [separator, message]
     for tensor, change in changes.items():
         data_added = change["data_added"]
+        data_added_str = convert_adds_to_string(data_added)
         data_updated = change["data_updated"]
         created = change.get("created", False)
-        has_change = created or data_added or data_updated
+        has_change = created or data_added_str or data_updated
         if has_change:
             all_changes.append(tensor)
             if created:
                 all_changes.append("* Created tensor")
 
-            if data_added:
-                output = convert_changes_to_string(data_added, "Added")
-                all_changes.append(output)
+            if data_added_str:
+                all_changes.append(data_added_str)
 
             if data_updated:
-                output = convert_changes_to_string(data_updated, "Updated")
+                output = convert_updates_to_string(data_updated)
                 all_changes.append(output)
             all_changes.append("")
     if len(all_changes) == 2:
@@ -126,7 +126,10 @@ def get_changes_for_id(commit_id: str, storage: LRUCache, changes: Dict[str, Any
             commit_diff_key = get_tensor_commit_diff_key(tensor, commit_id)
             commit_diff: CommitDiff = storage.get_cachable(commit_diff_key, CommitDiff)
             change = changes[tensor]
-            change["data_added"].update(commit_diff.data_added)
+            if change.get("data_added") is None:
+                change["data_added"] = commit_diff.data_added.copy()
+            else:
+                change["data_added"][0] = commit_diff.data_added[0]
             change["data_updated"].update(commit_diff.data_updated)
             change["created"] = change.get("created") or commit_diff.created
         except KeyError:
@@ -137,7 +140,9 @@ def filter_data_updated(changes: Dict[str, Any]):
     """Removes the intersection of data added and data updated from data updated."""
     for change in changes.values():
         # only show the elements in data_updated that are not in data_added
-        change["data_updated"] = change["data_updated"] - change["data_added"]
+        data_added_range = range(change["data_added"][0], change["data_added"][1] + 1)
+        upd = {data for data in change["data_updated"] if data not in data_added_range}
+        change["data_updated"] = upd
 
 
 def create_changes_dict() -> Dict[str, Any]:
@@ -203,10 +208,18 @@ def range_interval_list_to_string(range_intervals: List[Tuple[int, int]]) -> str
     return output[:-2]
 
 
-def convert_changes_to_string(indexes: Set[int], change_type: str = "") -> str:
+def convert_updates_to_string(indexes: Set[int]) -> str:
     range_intervals = compress_into_range_intervals(indexes)
     output = range_interval_list_to_string(range_intervals)
 
     num_samples = len(indexes)
     sample_string = "sample" if num_samples == 1 else "samples"
-    return f"* {change_type} {num_samples} {sample_string}: [{output}]"
+    return f"* Updated {num_samples} {sample_string}: [{output}]"
+
+
+def convert_adds_to_string(index_range: List[int]) -> str:
+    num_samples = index_range[1] - index_range[0]
+    if num_samples == 0:
+        return ""
+    sample_string = "sample" if num_samples == 1 else "samples"
+    return f"* Added {num_samples} {sample_string}: [{index_range[0]}-{index_range[1]}]"

--- a/hub/util/diff.py
+++ b/hub/util/diff.py
@@ -94,11 +94,17 @@ def get_changes_str(changes: Dict, message: str, separator: str):
     """Returns a string with changes made."""
     all_changes = [separator, message]
     for tensor, change in changes.items():
+
         data_added = change["data_added"]
         data_added_str = convert_adds_to_string(data_added)
+
         data_updated = change["data_updated"]
+
         created = change.get("created", False)
-        has_change = created or data_added_str or data_updated
+
+        info_updated = change.get("info_updated", False)
+
+        has_change = created or data_added_str or data_updated or info_updated
         if has_change:
             all_changes.append(tensor)
             if created:
@@ -110,6 +116,9 @@ def get_changes_str(changes: Dict, message: str, separator: str):
             if data_updated:
                 output = convert_updates_to_string(data_updated)
                 all_changes.append(output)
+
+            if info_updated:
+                all_changes.append("* Info updated")
             all_changes.append("")
     if len(all_changes) == 2:
         all_changes.append("No changes were made.")
@@ -138,6 +147,9 @@ def get_changes_for_id(commit_id: str, storage: LRUCache, changes: Dict[str, Dic
                 change["data_updated"].update(commit_diff.data_updated)
 
             change["created"] = change.get("created") or commit_diff.created
+            change["info_updated"] = (
+                change.get("info_updated") or commit_diff.info_updated
+            )
         except KeyError:
             pass
 

--- a/hub/util/encoder.py
+++ b/hub/util/encoder.py
@@ -196,6 +196,7 @@ def merge_all_commit_diffs(
             current_commit_diff = current_worker_commit_diffs[tensor]
             if commit_diff is None:
                 commit_diff = current_commit_diff
+                commit_diff.transform_data()
             else:
                 combine_commit_diffs(commit_diff, current_commit_diff)
 
@@ -207,5 +208,4 @@ def combine_commit_diffs(
     ds_commit_diff: CommitDiff, worker_commit_diff: CommitDiff
 ) -> None:
     """Combines the dataset's commit_diff with a single worker's commit_diff."""
-    ds_commit_diff.data_updated.update(worker_commit_diff.data_updated)
     ds_commit_diff.add_data(worker_commit_diff.num_samples_added)

--- a/hub/util/encoder.py
+++ b/hub/util/encoder.py
@@ -7,8 +7,10 @@ from hub.core.meta.encode.chunk_id import ChunkIdEncoder
 from hub.core.meta.encode.tile import TileEncoder
 from hub.core.storage.provider import StorageProvider
 from hub.core.version_control.commit_chunk_set import CommitChunkSet
+from hub.core.version_control.commit_diff import CommitDiff
 from hub.util.keys import (
     get_tensor_commit_chunk_set_key,
+    get_tensor_commit_diff_key,
     get_tensor_meta_key,
     get_chunk_id_encoder_key,
     get_chunk_id_encoder_key,
@@ -176,3 +178,34 @@ def combine_commit_chunk_sets(
 ) -> None:
     """Combines the dataset's commit_chunk_set with a single worker's commit_chunk_set."""
     ds_commit_chunk_set.chunks.update(worker_commit_chunk_set.chunks)
+
+
+def merge_all_commit_diffs(
+    all_workers_commit_diffs: List[Dict[str, CommitDiff]],
+    target_ds: hub.Dataset,
+    storage: StorageProvider,
+    overwrite: bool,
+) -> None:
+    """Merges commit_diffs from all workers into a single one and stores it in target_ds."""
+    tensors = list(target_ds.meta.tensors)
+    commit_id = target_ds.version_state["commit_id"]
+    for tensor in tensors:
+        rel_path = posixpath.relpath(tensor, target_ds.group_index)  # type: ignore
+        commit_diff = None if overwrite else target_ds[rel_path].chunk_engine.commit_diff  # type: ignore
+        for current_worker_commit_diffs in all_workers_commit_diffs:
+            current_commit_diff = current_worker_commit_diffs[tensor]
+            if commit_diff is None:
+                commit_diff = current_commit_diff
+            else:
+                combine_commit_diffs(commit_diff, current_commit_diff)
+
+        commit_chunk_key = get_tensor_commit_diff_key(tensor, commit_id)
+        storage[commit_chunk_key] = commit_diff.tobytes()  # type: ignore
+
+
+def combine_commit_diffs(
+    ds_commit_diff: CommitDiff, worker_commit_diff: CommitDiff
+) -> None:
+    """Combines the dataset's commit_diff with a single worker's commit_diff."""
+    ds_commit_diff.data_updated.update(worker_commit_diff.data_updated)
+    ds_commit_diff.add_data(worker_commit_diff.num_samples_added)

--- a/hub/util/transform.py
+++ b/hub/util/transform.py
@@ -12,6 +12,7 @@ from hub.core.ipc import Client
 
 from hub.constants import MB, TRANSFORM_PROGRESSBAR_UPDATE_INTERVAL
 from hub.core.version_control.commit_chunk_set import CommitChunkSet
+from hub.core.version_control.commit_diff import CommitDiff
 from hub.util.remove_cache import get_base_storage
 from hub.util.keys import get_tensor_meta_key
 from hub.util.exceptions import (
@@ -98,6 +99,7 @@ def store_data_slice(
     Dict[str, ChunkIdEncoder],
     Dict[str, TileEncoder],
     Dict[str, Optional[CommitChunkSet]],
+    Dict[str, CommitDiff],
 ]:
     """Takes a slice of the original data and iterates through it and stores it in the actual storage.
     The tensor_meta and chunk_id_encoder are not stored to the storage to prevent overwrites/race conditions b/w workers.

--- a/hub/util/transform.py
+++ b/hub/util/transform.py
@@ -121,11 +121,12 @@ def store_data_slice(
         data_slice, pipeline, tensors, all_chunk_engines, group_index, progress_port
     )
 
-    # retrieve the tensor metas and chunk_id_encoder from the memory
+    # retrieve relevant objects from memory
     all_tensor_metas = {}
     all_chunk_id_encoders = {}
     all_tile_encoders = {}
     all_chunk_sets = {}
+    all_commit_diffs = {}
     for tensor, chunk_engine in all_chunk_engines.items():
         chunk_engine.cache.flush()
         chunk_engine.meta_cache.flush()
@@ -133,7 +134,14 @@ def store_data_slice(
         all_chunk_id_encoders[tensor] = chunk_engine.chunk_id_encoder
         all_tile_encoders[tensor] = chunk_engine.tile_encoder
         all_chunk_sets[tensor] = chunk_engine.commit_chunk_set
-    return all_tensor_metas, all_chunk_id_encoders, all_tile_encoders, all_chunk_sets
+        all_commit_diffs[tensor] = chunk_engine.commit_diff
+    return (
+        all_tensor_metas,
+        all_chunk_id_encoders,
+        all_tile_encoders,
+        all_chunk_sets,
+        all_commit_diffs,
+    )
 
 
 def _transform_sample_and_update_chunk_engines(


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [x]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [x]  I have commented my code, particularly in hard-to-understand areas
- [x]  I have kept the `coverage-rate` up
- [x]  I have performed a self-review of my own code and resolved any problems
- [x]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [x]  I have described and made corresponding changes to the relevant documentation
- [x]  New and existing unit tests pass locally with my changes


### Changes

Compresses data_added in diff, to take up less storage by only storing first and last index added instead of full set.

The format of the dicts returned in diff has also been changed:-

```
{
    "image": {"data_added": [3, 6], "data_updated": {0, 2}, "created": False, "info_updated": False, "data_transformed_in_place": False},
    "label": {"data_added": [0, 3], "data_updated": {}, "created": True, "info_updated": False, "data_transformed_in_place": False},
    "other/stuff" : {data_added: [3, 3], data_updated: {1, 2}, created: True, "info_updated": False, "data_transformed_in_place": False}
}

```
Here the data_adeded is a range of sample indexes that were added to the tensor.
For example [3, 6] means that sample 3, 4 and 5 were added.
Another example [3, 3] means that no samples were added as the range is empty

data_updated on the other hand is a set of sample indexes that were updated.
For example {0, 2} means that sample 0 and 2 were updated.

"data_transformed_in_place" informs whether an inplace transformation happened in between the commits that are being looked at. 


Also fixes bug in which diff wasn't being considered in transforms