### PR TITLE
[AL-1592] Changes version control outputs

### DIFF
--- a/hub/core/dataset/dataset.py
+++ b/hub/core/dataset/dataset.py
@@ -391,7 +391,7 @@ class Dataset:
         version_state["full_tensors"] = {}  # keeps track of the full unindexed tensors
         self.version_state = version_state
 
-    def commit(self, message: Optional[str] = None) -> None:
+    def commit(self, message: Optional[str] = None) -> str:
         """Stores a snapshot of the current state of the dataset.
         Note: Commiting from a non-head node in any branch, will lead to an auto checkout to a new branch.
         This same behaviour will happen if new samples are added or existing samples are updated from a non-head node.
@@ -411,7 +411,7 @@ class Dataset:
         hub_reporter.feature_report(feature_name="commit", parameters={})
 
         self.storage.autoflush = initial_autoflush
-        return self.commit_id
+        return self.commit_id  # type: ignore
 
     def checkout(self, address: str, create: bool = False) -> Optional[str]:
         """Checks out to a specific commit_id or branch. If create = True, creates a new branch with name as address.

--- a/hub/core/dataset/dataset.py
+++ b/hub/core/dataset/dataset.py
@@ -54,6 +54,7 @@ from hub.util.version_control import (
     commit,
     commit_has_data,
     load_meta,
+    warn_node_checkout,
 )
 from tqdm import tqdm  # type: ignore
 
@@ -434,6 +435,8 @@ class Dataset:
         hub_reporter.feature_report(
             feature_name="checkout", parameters={"Create": str(create)}
         )
+        commit_node = self.version_state["commit_node"]
+        warn_node_checkout(commit_node, create)
 
         self.storage.autoflush = initial_autoflush
         return self.commit_id

--- a/hub/core/dataset/dataset.py
+++ b/hub/core/dataset/dataset.py
@@ -465,15 +465,15 @@ class Dataset:
             id_2 (str, optional): The second commit_id or branch name.
             as_dict (bool, optional): If True, returns dictionares of the differences instead of printing them. Defaults to False.
 
-        If both id_1 and id_2 are None, the differences between the current commit and the previous commit will be calculated.
-        If only id_1 is provided, the differences between the current commit and id_1 will be calculated.
+        If both id_1 and id_2 are None, the differences between the current state and the previous commit will be calculated. If you're at the head of the branch, this will show the uncommitted changes, if any.
+        If only id_1 is provided, the differences between the current state and id_1 will be calculated. If you're at the head of the branch, this will take into account the uncommitted changes, if any.
         If only id_2 is provided, a ValueError will be raised.
         If both id_1 and id_2 are provided, the differences between id_1 and id_2 will be calculated.
 
         Returns:
             Union[Dict, Tuple[Dict, Dict]]: The differences between the commits/branches if as_dict is True.
-                If id_1 and id_2 are None, a single dictionary containing the differences between the current commit and the previous commit will be returned.
-                If only id_1 is provided, two dictionaries containing the differences in the current commit and id_1 respectively will be returned.
+                If id_1 and id_2 are None, a single dictionary containing the differences between the current state and the previous commit will be returned.
+                If only id_1 is provided, two dictionaries containing the differences in the current state and id_1 respectively will be returned.
                 If only id_2 is provided, a ValueError will be raised.
                 If both id_1 and id_2 are provided, two dictionaries containing the differences in id_1 and id_2 respectively will be returned.
             None: If as_dict is False.

--- a/hub/core/transform/test_transform.py
+++ b/hub/core/transform/test_transform.py
@@ -595,7 +595,7 @@ def test_inplace_transform_non_head(local_ds_generator):
 
         # transforming non-head node
         inplace_transform().eval(ds, num_workers=4)
-        b = ds.commit_id
+        br = ds.branch
 
         assert len(ds) == 200
         for i in range(200):
@@ -622,7 +622,7 @@ def test_inplace_transform_non_head(local_ds_generator):
     for i in range(100):
         check_target_array(ds, i, 1)
 
-    ds.checkout(b)
+    ds.checkout(br)
     assert len(ds) == 200
     for i in range(200):
         target = 2 if i % 2 == 0 else 3

--- a/hub/core/transform/transform.py
+++ b/hub/core/transform/transform.py
@@ -260,7 +260,7 @@ class Pipeline:
         merge_all_chunk_id_encoders(
             all_chunk_id_encoders, target_ds, storage, overwrite
         )
-        if target_ds.commit_id != FIRST_COMMIT_ID:
+        if target_ds.commit_id is not None:
             merge_all_commit_chunk_sets(
                 all_chunk_commit_sets, target_ds, storage, overwrite
             )

--- a/hub/core/version_control/commit_node.py
+++ b/hub/core/version_control/commit_node.py
@@ -31,4 +31,9 @@ class CommitNode:
     def __repr__(self) -> str:
         return f"Commit : {self.commit_id} ({self.branch}) \nAuthor : {self.commit_user_name}\nTime   : {str(self.commit_time)[:-7]}\nMessage: {self.commit_message}"
 
+    @property
+    def is_head_node(self) -> bool:
+        """Returns True if the node is the head node of the branch."""
+        return self.commit_time is None
+
     __str__ = __repr__

--- a/hub/core/version_control/test_version_control.py
+++ b/hub/core/version_control/test_version_control.py
@@ -558,6 +558,27 @@ def test_diff_linear(local_ds, capsys):
     assert diff[0] == changes_b_from_a
     assert diff[1] == changes_empty
 
+    local_ds.checkout(b)
+    local_ds.diff()
+    message1 = f"Diff in {b} (current commit):\n"
+    target = get_all_changes_string(changes_b_from_a, message1, None, None) + "\n"
+    captured = capsys.readouterr()
+    assert captured.out == target
+    diff = local_ds.diff(as_dict=True)
+    assert diff == changes_b_from_a
+
+    local_ds.diff(a)
+    message1 = f"Diff in {b} (current commit):\n"
+    message2 = f"Diff in {a} (target id):\n"
+    target = (
+        get_all_changes_string(changes_b_from_a, message1, changes_empty, message2)
+        + "\n"
+    )
+    captured = capsys.readouterr()
+    assert captured.out == target
+    diff = local_ds.diff(a, as_dict=True)
+    assert isinstance(diff, tuple)
+
 
 def test_diff_branch(local_ds, capsys):
     with local_ds:

--- a/hub/util/chunk_paths.py
+++ b/hub/util/chunk_paths.py
@@ -6,7 +6,7 @@ from hub.util.keys import get_chunk_key
 
 def get_chunk_paths(dataset: hub.Dataset, tensors: List[str]) -> Set[str]:
     """Returns the paths to the chunks present in the current commit of the dataset"""
-    commit_id = dataset.commit_id
+    commit_id = dataset.pending_commit_id
     chunk_paths = set()
     for tensor in tensors:
         chunk_engine = dataset[tensor].chunk_engine

--- a/hub/util/version_control.py
+++ b/hub/util/version_control.py
@@ -229,7 +229,7 @@ def save_version_info(version_state: Dict[str, Any], storage: LRUCache) -> None:
 
 def auto_checkout(version_state: Dict[str, Any], storage: LRUCache) -> None:
     """Automatically checks out if current node is not the head node of the branch. This may happen either during commit/setitem/append/extend/create_tensor/info updates."""
-    if version_state["commit_node"].commit_time is not None:
+    if not version_state["commit_node"].is_head_node:
         current_branch = version_state["branch"]
         auto_branch = f"auto_{generate_hash()}"
         logger.info(
@@ -241,7 +241,7 @@ def auto_checkout(version_state: Dict[str, Any], storage: LRUCache) -> None:
 def auto_commit(version_state: Dict[str, Any], storage: LRUCache, address: str) -> None:
     """Automatically commits to the current branch before a checkout to a newly created branch if the current node is the head node."""
     commit_node = version_state["commit_node"]
-    if not commit_node.commit_time:
+    if commit_node.is_head_node:
         original_commit_id = version_state["commit_id"]
         branch = version_state["branch"]
         logger.info(

--- a/hub/util/version_control.py
+++ b/hub/util/version_control.py
@@ -3,6 +3,7 @@ import time
 import hashlib
 import pickle
 from typing import Any, Dict
+import warnings
 from hub.client.log import logger
 from hub.constants import FIRST_COMMIT_ID
 from hub.core.fast_forwarding import ffw_dataset_meta
@@ -296,3 +297,16 @@ def load_meta(storage, version_state):
 
     for tensor_name in meta.tensors:
         _tensors[tensor_name] = Tensor(tensor_name, storage, version_state)
+
+
+def warn_node_checkout(commit_node: CommitNode, create: bool):
+    """Throws a warning if there are no commits in a branch after checkout.
+    This warning isn't thrown if the branch was newly created.
+    """
+    if not create and commit_node.is_head_node:
+        branch = commit_node.branch
+        parent = commit_node.parent
+        if parent is None or parent.branch != branch:
+            warnings.warn(
+                f"The branch ({branch}) that you have checked out to, has no commits."
+            )


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [x]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [x]  I have commented my code, particularly in hard-to-understand areas
- [x]  I have kept the `coverage-rate` up
- [x]  I have performed a self-review of my own code and resolved any problems
- [x]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [x]  I have described and made corresponding changes to the relevant documentation
- [x]  New and existing unit tests pass locally with my changes


### Changes

Changes the behaviour of version control commands to return git like commit ids.
ds.commit_id will now return the id of the last commit that was made rather than the next commit id that will be made.
A similar change has been made to checkout, to return the last commit made rather than the commit id of the new branch.