### PR TITLE
removing hub_shm since it is no longer required

### DIFF
--- a/hub/requirements/common.txt
+++ b/hub/requirements/common.txt
@@ -12,7 +12,6 @@ types-click
 tqdm
 lz4
 typing_extensions>=3.10.0.0
-hub_shm; python_version < "3.8" and python_version >= "3.6"
 numcodecs~=0.7.3
 pickle5>=0.0.11; python_version < "3.8" and python_version >= "3.6"
 miniaudio~=1.44


### PR DESCRIPTION
## 🚀 🚀 Pull Request
removing hub_shm since it is no longer required
https://github.com/activeloopai/Hub/search?q=shm returns nothing

### Checklist:

- [x]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [x]  I have commented my code, particularly in hard-to-understand areas
- [x]  I have kept the `coverage-rate` up
- [x]  I have performed a self-review of my own code and resolved any problems
- [x]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [x]  I have described and made corresponding changes to the relevant documentation
- [x]  New and existing unit tests pass locally with my changes


### Changes
removing hub_shm since it is no longer required

<!-- Describe your changes! Describe the scope of this PR's responsibilities. -->