### PR TITLE
Enable intellisense for hub compute functions

### DIFF
--- a/hub/util/transform.py
+++ b/hub/util/transform.py
@@ -311,15 +311,15 @@ def check_transform_ds_out(ds_out: hub.Dataset, scheduler: str) -> None:
         )
 
 
-def get_pbar_description(transform_functions: List):
-    """Returns the description string for a hub.compute evaluation progress bar. Incoming list should be a list of `TransformFunction`s."""
+def get_pbar_description(compute_functions: List):
+    """Returns the description string for a hub.compute evaluation progress bar. Incoming list should be a list of `ComputeFunction`s."""
 
-    num_funcs = len(transform_functions)
+    num_funcs = len(compute_functions)
     if num_funcs == 0:
         return "Evaluating"
 
     func_names: List[str] = []
-    for transform_function in transform_functions:
+    for transform_function in compute_functions:
         func_names.append(transform_function.func.__name__)
 
     if num_funcs == 1:


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [ ]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [ ]  I have performed a self-review of my own code and resolved any problems
- [ ]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [ ]  New and existing unit tests pass locally with my changes


### Changes

- Functions decorated with @hub.compute will now show proper IntelliSense while using .eval()
- Changed class name from TransformFunction to ComputeFunction