### PR TITLE
Tweak tile encoder format

### DIFF
--- a/hub/api/tests/test_api_tiling.py
+++ b/hub/api/tests/test_api_tiling.py
@@ -1,6 +1,8 @@
 import pytest
 import numpy as np
 
+from hub.constants import MB
+
 compressions_paremetrized = pytest.mark.parametrize(
     "compression",
     [
@@ -150,10 +152,10 @@ def test_empty_array(memory_ds, compression):
     ds = memory_ds
     arr_list = [
         np.random.randint(0, 255, (3894, 4279, 0), dtype=np.uint8),
-        np.random.randint(0, 255, (3894, 4279, 3), dtype=np.uint8),
+        np.random.randint(0, 255, (1089, 1027, 3), dtype=np.uint8),
     ]
     with ds:
-        ds.create_tensor("x", **compression)
+        ds.create_tensor("x", **compression, max_chunk_size=1 * MB)
         ds.x.extend(arr_list)
     assert len(ds) == 2
     assert len(ds.x) == 2

--- a/hub/core/meta/encode/tile.py
+++ b/hub/core/meta/encode/tile.py
@@ -1,6 +1,6 @@
 import hub
 import numpy as np
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Literal, Optional, Tuple, Union
 
 from hub.core.storage.cachable import Cachable
 from hub.core.tiling.sample_tiles import SampleTiles
@@ -179,7 +179,9 @@ class TileEncoder(Cachable):
         self.version = state["version"]
 
 
-def parse_tile_encoder_entries(data, ofs: int, byteorder: str) -> Optional[Dict]:
+def parse_tile_encoder_entries(
+    data, ofs: int, byteorder: Union[Literal["little"], Literal["big"]]
+) -> Optional[Dict]:
     # Get the number of entries
     num_entries = int.from_bytes(data[ofs : ofs + 8], byteorder=byteorder)
     ofs += 8

--- a/hub/core/meta/encode/tile.py
+++ b/hub/core/meta/encode/tile.py
@@ -1,15 +1,15 @@
 import hub
 import numpy as np
-from typing import Any, Dict, Tuple
+from typing import Any, Dict, List, Tuple
 
 from hub.core.storage.cachable import Cachable
 from hub.core.tiling.sample_tiles import SampleTiles
 
 
 class TileEncoder(Cachable):
-    def __init__(self, entries=None):
+    def __init__(self, entries=None, version=None):
         self.entries: Dict[int, Tuple[Tuple[int, ...], Tuple[int, ...]]] = entries or {}
-        self.version = hub.__version__
+        self.version = version or hub.__version__
 
     def register_sample(self, sample: SampleTiles, idx: int):
         """Registers a new tiled sample into the encoder.
@@ -68,13 +68,14 @@ class TileEncoder(Cachable):
 
     @property
     def nbytes(self):
+        len_version = 1 + len(self.version)
         entries = self.entries
         num_entries = len(entries)
         if num_entries == 0:
-            return 8
+            return len_version + 8
         value = next(iter(entries.values()))
         num_dimensions = len(value[0])
-        return 16 + (num_entries * (8 * (1 + num_dimensions * 2)))
+        return len_version + 16 + (num_entries * (8 * (1 + num_dimensions * 2)))
 
     def tobytes(self) -> memoryview:
         """Serialize entries dict into bytes
@@ -93,9 +94,11 @@ class TileEncoder(Cachable):
         }
         All the tuples inside will have the same number of dimensions.
         The format stores the following information in order:
-        1. The first 8 bytes are the number of entries call this n.
-        2. The next 8 bytes are the number of dimensions in the shapes, call this d.
-        3. The next n * (8 * (1 + d + d)) bytes are the entries in the format:
+        1. First byte tells the length of the version string, call this v.
+        2. The next v bytes are the version string.
+        3. The next 8 bytes are the number of entries call this n.
+        4. The next 8 bytes are the number of dimensions in the shapes, call this d.
+        5. The next n * (8 * (1 + d + d)) bytes are the entries in the format:
             a. The first 8 bytes are the key.
             b. The next d * 8 bytes are the first shape in value.
             c. The next d * 8 bytes are the second shape in value.
@@ -106,8 +109,16 @@ class TileEncoder(Cachable):
         data = bytearray(self.nbytes)
         ofs = 0
 
+        # store version length
+        data[ofs] = len(self.version)
+        ofs += 1
+
+        # store version string
+        data[ofs : ofs + len(self.version)] = self.version.encode("ascii")
+        ofs += len(self.version)
+
         # store the number of entries
-        data[ofs : ofs + 8] = num_entries.to_bytes(8, byteorder="big")
+        data[ofs : ofs + 8] = num_entries.to_bytes(8, byteorder="little")
         ofs += 8
 
         if num_entries == 0:
@@ -117,25 +128,25 @@ class TileEncoder(Cachable):
         num_dimensions = len(value[0])
 
         # store the number of dimensions
-        data[ofs : ofs + 8] = num_dimensions.to_bytes(8, byteorder="big")
+        data[ofs : ofs + 8] = num_dimensions.to_bytes(8, byteorder="little")
         ofs += 8
 
         # store the entries
         for key, value in entries.items():
             # store the key
-            data[ofs : ofs + 8] = key.to_bytes(8, byteorder="big")
+            data[ofs : ofs + 8] = key.to_bytes(8, byteorder="little")
             ofs += 8
 
             # store the first shape
             first_shape = value[0]
             for dimension in first_shape:
-                data[ofs : ofs + 8] = dimension.to_bytes(8, byteorder="big")
+                data[ofs : ofs + 8] = dimension.to_bytes(8, byteorder="little")
                 ofs += 8
 
             # store the second shape
             second_shape = value[1]
             for dimension in second_shape:
-                data[ofs : ofs + 8] = dimension.to_bytes(8, byteorder="big")
+                data[ofs : ofs + 8] = dimension.to_bytes(8, byteorder="little")
                 ofs += 8
 
         return memoryview(data)
@@ -143,51 +154,44 @@ class TileEncoder(Cachable):
     @classmethod
     def frombuffer(cls, data: bytes):
         """Deserialize bytes into entries dict"""
+        ofs = 0
+        # Get version length
+        version_length = data[0]
+        ofs += 1
+
+        # Get version string
+        version = str(data[1 : 1 + version_length], "ascii")
+        ofs += version_length
 
         # Get the number of entries
-        num_entries = int.from_bytes(data[:8], byteorder="big")
+        num_entries = int.from_bytes(data[ofs : ofs + 8], byteorder="little")
+        ofs += 8
         if num_entries == 0:
-            return cls()
+            return cls(version=version)
 
         # Get the number of dimensions of the tuples
-        num_dim = int.from_bytes(data[8:16], byteorder="big")
+        num_dim = int.from_bytes(data[ofs : ofs + 8], byteorder="little")
+        ofs += 8
 
         # Get the entries
         entries = {}
-        for i in range(num_entries):
-
-            ofs = i * (8 * (1 + num_dim * 2))
+        for _ in range(num_entries):
             # Get the key
-            key = int.from_bytes(
-                data[16 + ofs : 16 + ofs + 8],
-                byteorder="big",
-            )
+            key = int.from_bytes(data[ofs : ofs + 8], byteorder="little")
+            ofs += 8
 
-            # Get the first shape
-            ofs_1 = 24 + ofs
-            first_shape = [
-                int.from_bytes(
-                    data[ofs_1 + (j * 8) : ofs_1 + (j * 8) + 8],
-                    byteorder="big",
-                )
-                for j in range(num_dim)
-            ]
+            first_shape: List[int] = []
+            second_shape: List[int] = []
+
+            for shp in [first_shape, second_shape]:
+                for _ in range(num_dim):
+                    shp.append(int.from_bytes(data[ofs : ofs + 8], byteorder="little"))
+                    ofs += 8
             first_shape = tuple(first_shape)  # type: ignore
-            # Get the second shape
-            ofs_2 = 24 + ofs + (num_dim * 8)
-
-            second_shape = [
-                int.from_bytes(
-                    data[ofs_2 + (j * 8) : ofs_2 + (j * 8) + 8],
-                    byteorder="big",
-                )
-                for j in range(num_dim)
-            ]
             second_shape = tuple(second_shape)  # type: ignore
             # Add the entry to the dict
             entries[key] = (first_shape, second_shape)
-
-        return cls(entries)
+        return cls(entries, version=version)
 
     def __getstate__(self) -> Dict[str, Any]:
         return {"entries": self.entries, "version": self.version}

--- a/hub/core/meta/encode/tile.py
+++ b/hub/core/meta/encode/tile.py
@@ -1,7 +1,6 @@
 import hub
 import numpy as np
-from typing import Any, Dict, List, Literal, Optional, Tuple, Union
-
+from typing import Any, Dict, List, Optional, Tuple
 from hub.core.storage.cachable import Cachable
 from hub.core.tiling.sample_tiles import SampleTiles
 
@@ -179,24 +178,22 @@ class TileEncoder(Cachable):
         self.version = state["version"]
 
 
-def parse_tile_encoder_entries(
-    data, ofs: int, byteorder: Union[Literal["little"], Literal["big"]]
-) -> Optional[Dict]:
+def parse_tile_encoder_entries(data, ofs: int, byteorder: str) -> Optional[Dict]:
     # Get the number of entries
-    num_entries = int.from_bytes(data[ofs : ofs + 8], byteorder=byteorder)
+    num_entries = int.from_bytes(data[ofs : ofs + 8], byteorder=byteorder)  # type: ignore
     ofs += 8
     if num_entries == 0:
         return
 
     # Get the number of dimensions of the tuples
-    num_dim = int.from_bytes(data[ofs : ofs + 8], byteorder=byteorder)
+    num_dim = int.from_bytes(data[ofs : ofs + 8], byteorder=byteorder)  # type: ignore
     ofs += 8
 
     # Get the entries
     entries = {}
     for _ in range(num_entries):
         # Get the key
-        key = int.from_bytes(data[ofs : ofs + 8], byteorder=byteorder)
+        key = int.from_bytes(data[ofs : ofs + 8], byteorder=byteorder)  # type: ignore
         ofs += 8
 
         first_shape: List[int] = []
@@ -204,7 +201,7 @@ def parse_tile_encoder_entries(
 
         for shp in [first_shape, second_shape]:
             for _ in range(num_dim):
-                shp.append(int.from_bytes(data[ofs : ofs + 8], byteorder=byteorder))
+                shp.append(int.from_bytes(data[ofs : ofs + 8], byteorder=byteorder))  # type: ignore
                 ofs += 8
 
         # Add the entry to the dict

--- a/hub/core/meta/encode/tile.py
+++ b/hub/core/meta/encode/tile.py
@@ -178,12 +178,12 @@ class TileEncoder(Cachable):
         self.version = state["version"]
 
 
-def parse_tile_encoder_entries(data, ofs: int, byteorder: str) -> Optional[Dict]:
+def parse_tile_encoder_entries(data, ofs: int, byteorder: str) -> Dict:
     # Get the number of entries
     num_entries = int.from_bytes(data[ofs : ofs + 8], byteorder=byteorder)  # type: ignore
     ofs += 8
     if num_entries == 0:
-        return
+        return {}
 
     # Get the number of dimensions of the tuples
     num_dim = int.from_bytes(data[ofs : ofs + 8], byteorder=byteorder)  # type: ignore

--- a/hub/core/meta/encode/tile.py
+++ b/hub/core/meta/encode/tile.py
@@ -163,7 +163,7 @@ class TileEncoder(Cachable):
             # Get version string
             version = str(data[1 : 1 + version_length], "ascii")
             ofs += version_length
-
+            check_version(version)
             entries = parse_tile_encoder_entries(data, ofs, "little")
             return cls(entries, version=version)
         except Exception:
@@ -208,3 +208,10 @@ def parse_tile_encoder_entries(data, ofs: int, byteorder: str) -> Optional[Dict]
         # Add the entry to the dict
         entries[key] = (tuple(first_shape), tuple(second_shape))
     return entries
+
+
+def check_version(version):
+    if len(version) < 5:
+        raise ValueError("Invalid version length")
+    if version.count(".") < 2:
+        raise ValueError("Invalid version format")

--- a/hub/core/meta/encode/tile.py
+++ b/hub/core/meta/encode/tile.py
@@ -210,7 +210,7 @@ def parse_tile_encoder_entries(data, ofs: int, byteorder: str) -> Dict:
 
 
 def check_version(version):
-    if len(version) < 5:
+    if len(version) < 5 or len(version) > 7:
         raise ValueError("Invalid version length")
-    if version.count(".") < 2:
+    if version.count(".") < 2 or version[0] != "2":
         raise ValueError("Invalid version format")


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [ ]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [ ]  I have performed a self-review of my own code and resolved any problems
- [ ]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [ ]  New and existing unit tests pass locally with my changes


### Changes

Slightly changes tile encoder storage format to use little endian ordering to be consistent with other encoders.
The version string is also now added to the bytes at the start