### PR TITLE
Fix repeated key misses slowing down Version Controlled datasets

### DIFF
--- a/hub/core/chunk_engine.py
+++ b/hub/core/chunk_engine.py
@@ -447,6 +447,11 @@ class ChunkEngine:
                         chunk_set_key, CommitChunkSet
                     ).chunks
             except Exception:
+                commit_chunk_set = CommitChunkSet()
+                try:
+                    self.meta_cache[chunk_set_key] = commit_chunk_set
+                except ReadOnlyModeError:
+                    pass
                 chunk_set = set()
             if chunk_name in chunk_set:
                 return commit_id

--- a/hub/core/chunk_engine.py
+++ b/hub/core/chunk_engine.py
@@ -391,11 +391,11 @@ class ChunkEngine:
         chunk_commit_id = self.get_chunk_commit(chunk_name)
         chunk_key = get_chunk_key(self.key, chunk_name, chunk_commit_id)
         chunk = self.get_chunk(chunk_key)
+        chunk.key = chunk_key  # type: ignore
+        chunk.id = self.last_chunk_id  # type: ignore
         if chunk_commit_id != self.commit_id:
             chunk = self.copy_chunk_to_new_commit(chunk, chunk_name)
         else:
-            chunk.key = chunk_key  # type: ignore
-            chunk.id = self.last_chunk_id  # type: ignore
             self.update_chunk_in_cache(chunk)
         return chunk
 
@@ -411,10 +411,10 @@ class ChunkEngine:
         chunk = self.cache.get_cachable(
             chunk_key, self.chunk_class, meta=self.chunk_args
         )
-        chunk.key = chunk_key
+        chunk.key = chunk_key  # type: ignore
+        chunk.id = chunk_id  # type: ignore
         if copy and chunk_commit_id != self.commit_id:
             chunk = self.copy_chunk_to_new_commit(chunk, chunk_name)
-        chunk.id = chunk_id
         return chunk
 
     def copy_chunk_to_new_commit(self, chunk, chunk_name):

--- a/hub/core/tensor.py
+++ b/hub/core/tensor.py
@@ -1,3 +1,4 @@
+from hub.core.version_control.commit_chunk_set import CommitChunkSet
 from hub.core.version_control.commit_diff import CommitDiff
 from hub.core.chunk.base_chunk import InputSample
 import numpy as np
@@ -11,6 +12,7 @@ from hub.api.info import load_info
 from hub.util.keys import (
     get_chunk_id_encoder_key,
     get_chunk_key,
+    get_tensor_commit_chunk_set_key,
     get_tensor_commit_diff_key,
     get_tensor_meta_key,
     tensor_exists,
@@ -63,6 +65,10 @@ def create_tensor(
         **kwargs,
     )
     storage[meta_key] = meta  # type: ignore
+
+    cset_key = get_tensor_commit_chunk_set_key(key, version_state["commit_id"])
+    cset = CommitChunkSet()
+    storage[cset_key] = cset  # type: ignore
 
     diff_key = get_tensor_commit_diff_key(key, version_state["commit_id"])
     diff = CommitDiff(created=True)

--- a/hub/core/version_control/commit_chunk_set.py
+++ b/hub/core/version_control/commit_chunk_set.py
@@ -16,7 +16,8 @@ class CommitChunkSet(Cachable):
     def frombuffer(cls, buffer: bytes):
         """Loads a CommitChunkSet from a buffer."""
         instance = cls()
-        instance.chunks = set(buffer.decode("utf-8").split(","))
+        if buffer:
+            instance.chunks = set(buffer.decode("utf-8").split(","))
         return instance
 
     @property

--- a/hub/util/version_control.py
+++ b/hub/util/version_control.py
@@ -279,7 +279,7 @@ def create_commit_chunk_sets(
     storage: LRUCache,
     version_state: Dict[str, Any],
 ) -> None:
-    """Copies meta data from one commit to another."""
+    """Creates commit chunk sets for all tensors in new commit."""
     tensor_list = version_state["full_tensors"].keys()
     for tensor in tensor_list:
         key = get_tensor_commit_chunk_set_key(tensor, dest_commit_id)

--- a/hub/util/version_control.py
+++ b/hub/util/version_control.py
@@ -18,6 +18,7 @@ from hub.util.keys import (
     get_chunk_id_encoder_key,
     get_dataset_info_key,
     get_dataset_meta_key,
+    get_tensor_commit_chunk_set_key,
     get_tensor_commit_diff_key,
     get_tensor_info_key,
     get_tensor_meta_key,
@@ -110,6 +111,7 @@ def commit(dataset, message: str = None, hash: Optional[str] = None) -> None:
     copy_metas(
         dataset, stored_commit_id, version_state["commit_id"], storage, version_state
     )
+    create_commit_chunk_sets(version_state["commit_id"], storage, version_state)
     discard_old_metas(stored_commit_id, storage, version_state["full_tensors"])
     load_meta(dataset)
 
@@ -174,6 +176,7 @@ def checkout(
         version_state["branch_commit_map"][address] = new_commit_id
         save_version_info(version_state, storage)
         copy_metas(dataset, original_commit_id, new_commit_id, storage, version_state)
+        create_commit_chunk_sets(new_commit_id, storage, version_state)
         dataset._send_branch_creation_event(address)
     else:
         raise CheckoutError(
@@ -269,6 +272,18 @@ def copy_metas(
             pass
 
     storage.flush()
+
+
+def create_commit_chunk_sets(
+    dest_commit_id: str,
+    storage: LRUCache,
+    version_state: Dict[str, Any],
+) -> None:
+    """Copies meta data from one commit to another."""
+    tensor_list = version_state["full_tensors"].keys()
+    for tensor in tensor_list:
+        key = get_tensor_commit_chunk_set_key(tensor, dest_commit_id)
+        storage[key] = CommitChunkSet()
 
 
 def discard_old_metas(


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [ ]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [ ]  I have performed a self-review of my own code and resolved any problems
- [ ]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [ ]  New and existing unit tests pass locally with my changes


### Changes
Closes #1456 
New commits were created without a CommitChunkSet (until any new data was added), leading to repeated key misses that slow down iteration. If any data was added to the commit, this wasn't a problem.

This PR changes the logic to create a new empty CommitChunkSet every time a new commit/branch is created, to avoid these repeated key misses. It also tries to fix existing datasets that don't have a CommitChunkSet in any of their commits by adding it (if write access is available).