### PR TITLE
[Bug fix] Pytorch + old read only datasets

### DIFF
--- a/hub/core/io.py
+++ b/hub/core/io.py
@@ -381,7 +381,9 @@ class SampleStreaming(Streaming):
         return blocks
 
     def _use_cache(self, storage: Union[StorageProvider, LRUCache]) -> LRUCache:
-        return LRUCache(MemoryProvider(), copy(storage), 32 * MB)
+        cache = LRUCache(MemoryProvider(), copy(storage), 32 * MB)
+        cache.read_only = storage.read_only
+        return cache
 
     def _map_chunk_engines(self, tensors: Sequence[str]) -> Dict[str, ChunkEngine]:
         return {


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [ ]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [ ]  I have performed a self-review of my own code and resolved any problems
- [ ]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [ ]  New and existing unit tests pass locally with my changes


### Changes
- Can't add unit test for this as it only happens for old datasets that don't have chunk sets created.