### PR TITLE
Remote URL read test fix: Do not test with s3 & gcs if options not enabled

### DIFF
--- a/hub/api/tests/test_api.py
+++ b/hub/api/tests/test_api.py
@@ -995,3 +995,8 @@ def test_hub_remote_read(storage, memory_ds, video_paths, color_image_paths):
     image = hub.read(f"{storage.root}/sample/samplejpg.jpg")
     memory_ds.images.append(image)
     assert memory_ds.images[1].shape == (323, 480, 3)
+
+    storage["samplejpg.jpg"] = byts
+    image = hub.read(f"{storage.root}/samplejpg.jpg")
+    memory_ds.images.append(image)
+    assert memory_ds.images[2].shape == (323, 480, 3)

--- a/hub/api/tests/test_api.py
+++ b/hub/api/tests/test_api.py
@@ -1,5 +1,4 @@
 import os
-from urllib import request
 import numpy as np
 import pytest
 import hub

--- a/hub/api/tests/test_api.py
+++ b/hub/api/tests/test_api.py
@@ -1,10 +1,12 @@
 import os
+from urllib import request
 import numpy as np
 import pytest
 import hub
 from hub.core.dataset import Dataset
 from hub.core.tensor import Tensor
-from hub.tests.common import assert_array_lists_equal
+from hub.tests.common import assert_array_lists_equal, is_opt_true
+from hub.constants import S3_OPT, GCS_OPT
 from hub.util.exceptions import (
     TensorDtypeMismatchError,
     TensorAlreadyExistsError,
@@ -964,7 +966,7 @@ def test_sample_shape(memory_ds):
     assert ds.z[1][:2, 10:].shape == (2, 2990, 4000)
 
 
-def test_hub_remote_read(memory_ds, video_paths, color_image_paths):
+def test_hub_remote_read(request, memory_ds, video_paths, color_image_paths):
     image_path = color_image_paths["jpeg"]
     with open(image_path, "rb") as f:
         byts = f.read()
@@ -989,30 +991,32 @@ def test_hub_remote_read(memory_ds, video_paths, color_image_paths):
     # memory_ds.videos.append(video)
     # assert memory_ds.videos[1].shape == (360, 720, 1280, 3)
 
-    gcs = GCSProvider(f"{PYTEST_GCS_PROVIDER_BASE_ROOT}test_image/jpg")
-    gcs["sample/samplejpg.jpg"] = byts
-    image = hub.read(
-        f"{PYTEST_GCS_PROVIDER_BASE_ROOT}test_image/jpg/sample/samplejpg.jpg"
-    )
-    memory_ds.images.append(image)
-    assert memory_ds.images[1].shape == (323, 480, 3)
+    if is_opt_true(request, GCS_OPT):
+        gcs = GCSProvider(f"{PYTEST_GCS_PROVIDER_BASE_ROOT}test_image/jpg")
+        gcs["sample/samplejpg.jpg"] = byts
+        image = hub.read(
+            f"{PYTEST_GCS_PROVIDER_BASE_ROOT}test_image/jpg/sample/samplejpg.jpg"
+        )
+        memory_ds.images.append(image)
+        assert memory_ds.images[1].shape == (323, 480, 3)
 
-    gcs = GCSProvider(f"{PYTEST_GCS_PROVIDER_BASE_ROOT}")
-    gcs["samplejpg.jpg"] = byts
-    image = hub.read(f"{PYTEST_GCS_PROVIDER_BASE_ROOT}samplejpg.jpg")
-    memory_ds.images.append(image)
-    assert memory_ds.images[2].shape == (323, 480, 3)
+        gcs = GCSProvider(f"{PYTEST_GCS_PROVIDER_BASE_ROOT}")
+        gcs["samplejpg.jpg"] = byts
+        image = hub.read(f"{PYTEST_GCS_PROVIDER_BASE_ROOT}samplejpg.jpg")
+        memory_ds.images.append(image)
+        assert memory_ds.images[2].shape == (323, 480, 3)
 
-    s3 = S3Provider(f"{PYTEST_S3_PROVIDER_BASE_ROOT}test_image/jpg")
-    s3["sample/samplejpg.jpg"] = byts
-    image = hub.read(
-        f"{PYTEST_S3_PROVIDER_BASE_ROOT}test_image/jpg/sample/samplejpg.jpg",
-    )
-    memory_ds.images.append(image)
-    assert memory_ds.images[3].shape == (323, 480, 3)
+    if is_opt_true(request, S3_OPT):
+        s3 = S3Provider(f"{PYTEST_S3_PROVIDER_BASE_ROOT}test_image/jpg")
+        s3["sample/samplejpg.jpg"] = byts
+        image = hub.read(
+            f"{PYTEST_S3_PROVIDER_BASE_ROOT}test_image/jpg/sample/samplejpg.jpg",
+        )
+        memory_ds.images.append(image)
+        assert memory_ds.images[3].shape == (323, 480, 3)
 
-    s3 = S3Provider(f"{PYTEST_S3_PROVIDER_BASE_ROOT}")
-    s3["samplejpg.jpg"] = byts
-    image = hub.read(f"{PYTEST_S3_PROVIDER_BASE_ROOT}samplejpg.jpg")
-    memory_ds.images.append(image)
-    assert memory_ds.images[4].shape == (323, 480, 3)
+        s3 = S3Provider(f"{PYTEST_S3_PROVIDER_BASE_ROOT}")
+        s3["samplejpg.jpg"] = byts
+        image = hub.read(f"{PYTEST_S3_PROVIDER_BASE_ROOT}samplejpg.jpg")
+        memory_ds.images.append(image)
+        assert memory_ds.images[4].shape == (323, 480, 3)

--- a/hub/tests/storage_fixtures.py
+++ b/hub/tests/storage_fixtures.py
@@ -59,7 +59,7 @@ def s3_root_storage(request):
         pytest.skip()
         return
 
-    return S3Provider(f"{PYTEST_S3_PROVIDER_BASE_ROOT}")
+    return S3Provider(PYTEST_S3_PROVIDER_BASE_ROOT)
 
 
 @pytest.fixture
@@ -68,7 +68,7 @@ def gcs_root_storage(request, gcs_creds):
         pytest.skip()
         return
 
-    return GCSProvider(f"{PYTEST_GCS_PROVIDER_BASE_ROOT}", token=gcs_creds)
+    return GCSProvider(PYTEST_GCS_PROVIDER_BASE_ROOT, token=gcs_creds)
 
 
 @pytest.fixture

--- a/hub/tests/storage_fixtures.py
+++ b/hub/tests/storage_fixtures.py
@@ -3,6 +3,13 @@ from hub.util.storage import storage_provider_from_hub_path
 from hub.core.storage.s3 import S3Provider
 from hub.core.storage.local import LocalProvider
 from hub.core.storage.memory import MemoryProvider
+from hub.constants import (
+    PYTEST_S3_PROVIDER_BASE_ROOT,
+    PYTEST_GCS_PROVIDER_BASE_ROOT,
+    S3_OPT,
+    GCS_OPT,
+)
+from hub.tests.common import is_opt_true
 import pytest
 
 
@@ -21,7 +28,7 @@ enabled_persistent_storages = pytest.mark.parametrize(
 
 enabled_remote_storages = pytest.mark.parametrize(
     "storage",
-    ["s3_storage", "gcs_storage"],
+    ["s3_storage", "gcs_storage", "gcs_root_storage", "s3_root_storage"],
     indirect=True,
 )
 
@@ -44,6 +51,24 @@ def s3_storage(s3_path):
 @pytest.fixture
 def gcs_storage(gcs_path):
     return GCSProvider(gcs_path)
+
+
+@pytest.fixture
+def s3_root_storage(request):
+    if not is_opt_true(request, GCS_OPT):
+        pytest.skip()
+        return
+
+    return S3Provider(f"{PYTEST_S3_PROVIDER_BASE_ROOT}")
+
+
+@pytest.fixture
+def gcs_root_storage(request, gcs_creds):
+    if not is_opt_true(request, S3_OPT):
+        pytest.skip()
+        return
+
+    return GCSProvider(f"{PYTEST_GCS_PROVIDER_BASE_ROOT}", token=gcs_creds)
 
 
 @pytest.fixture

--- a/hub/tests/storage_fixtures.py
+++ b/hub/tests/storage_fixtures.py
@@ -19,6 +19,13 @@ enabled_persistent_storages = pytest.mark.parametrize(
 )
 
 
+enabled_remote_storages = pytest.mark.parametrize(
+    "storage",
+    ["s3_storage", "gcs_storage"],
+    indirect=True,
+)
+
+
 @pytest.fixture
 def memory_storage(memory_path):
     return MemoryProvider(memory_path)


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [ ]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [ ]  I have performed a self-review of my own code and resolved any problems
- [ ]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [ ]  New and existing unit tests pass locally with my changes


### Changes

<!-- Describe your changes! Describe the scope of this PR's responsibilities. -->