### PR TITLE
concise and storage fixtured remote tests

### DIFF
--- a/bin/docker-compose.yaml
+++ b/bin/docker-compose.yaml
@@ -14,8 +14,9 @@ services:
       dockerfile: ./bin/Dockerfile.dev
     volumes:
       - ../:/app
+    shm_size: 7.48gb
     command: >
-      bash -c "python3 -m pytest -x --local"
+      bash -c "python3 -m pytest --local ."
 
   complete:
     build:


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [x]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [x]  I have kept the `coverage-rate` up
- [x]  I have performed a self-review of my own code and resolved any problems
- [x]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [x]  New and existing unit tests pass locally with my changes


### Changes

Concise tests for remote read per storage