### PR TITLE
[AL-1677] Allow out of order data insertion (recommended for internal use only, will greatly impact performace if used incorrectly)

### DIFF
--- a/hub/api/tests/test_insertion_out_of_order.py
+++ b/hub/api/tests/test_insertion_out_of_order.py
@@ -1,3 +1,4 @@
+from unittest.mock import patch
 import numpy as np
 import pytest
 
@@ -12,6 +13,7 @@ all_non_image_compressions = pytest.mark.parametrize(
 )
 
 
+@patch("hub.constants._ENABLE_RANDOM_ASSIGNMENT", True)
 @all_non_image_compressions
 @pytest.mark.parametrize("insert_first", [True, False])
 def test_insertion_array(memory_ds, compression, insert_first):
@@ -22,7 +24,7 @@ def test_insertion_array(memory_ds, compression, insert_first):
         empty_sample = np.random.rand(0, 0, 0)
         if insert_first:
             ds.abc.append(first)
-        ds.abc.__setitem__(10, tenth, True)
+        ds.abc[10] = tenth
 
         if insert_first:
             np.testing.assert_array_equal(ds.abc[0].numpy(), first)
@@ -34,9 +36,10 @@ def test_insertion_array(memory_ds, compression, insert_first):
         np.testing.assert_array_equal(ds.abc[10].numpy(), tenth)
 
 
+@patch("hub.constants._ENABLE_RANDOM_ASSIGNMENT", True)
 @pytest.mark.parametrize("sample_compression", ["png", "jpeg"])
 @pytest.mark.parametrize("insert_first", [True, False])
-def test_insertion_array_png_jpeg(memory_ds, sample_compression, insert_first):
+def test_insertion_array_img_compressed(memory_ds, sample_compression, insert_first):
     with memory_ds as ds:
         ds.create_tensor("abc", sample_compression=sample_compression)
         first = np.random.randint(0, 256, (200, 300, 3), dtype=np.uint8)
@@ -44,7 +47,7 @@ def test_insertion_array_png_jpeg(memory_ds, sample_compression, insert_first):
         empty_sample = np.random.randint(0, 256, (0, 0, 0), dtype=np.uint8)
         if insert_first:
             ds.abc.append(first)
-        ds.abc.__setitem__(10, tenth, True)
+        ds.abc[10] = tenth
 
         if insert_first:
             if sample_compression == "png":
@@ -63,6 +66,7 @@ def test_insertion_array_png_jpeg(memory_ds, sample_compression, insert_first):
             assert ds.abc[10].numpy().shape == tenth.shape
 
 
+@patch("hub.constants._ENABLE_RANDOM_ASSIGNMENT", True)
 @all_non_image_compressions
 @pytest.mark.parametrize("insert_first", [True, False])
 def test_insertion_json(memory_ds, compression, insert_first):
@@ -73,7 +77,7 @@ def test_insertion_json(memory_ds, compression, insert_first):
         empty_sample = {}
         if insert_first:
             ds.abc.append(first)
-        ds.abc.__setitem__(10, tenth, True)
+        ds.abc[10] = tenth
 
         if insert_first:
             assert ds.abc[0].numpy()[0] == first
@@ -86,6 +90,7 @@ def test_insertion_json(memory_ds, compression, insert_first):
         assert ds.abc[10].numpy() == tenth
 
 
+@patch("hub.constants._ENABLE_RANDOM_ASSIGNMENT", True)
 @all_non_image_compressions
 @pytest.mark.parametrize("insert_first", [True, False])
 def test_insertion_text(memory_ds, compression, insert_first):
@@ -96,7 +101,7 @@ def test_insertion_text(memory_ds, compression, insert_first):
         empty_sample = ""
         if insert_first:
             ds.abc.append(first)
-        ds.abc.__setitem__(10, tenth, True)
+        ds.abc[10] = tenth
 
         if insert_first:
             assert ds.abc[0].numpy()[0] == first
@@ -109,6 +114,7 @@ def test_insertion_text(memory_ds, compression, insert_first):
         assert ds.abc[10].numpy() == tenth
 
 
+@patch("hub.constants._ENABLE_RANDOM_ASSIGNMENT", True)
 @all_non_image_compressions
 @pytest.mark.parametrize("insert_first", [True, False])
 def test_insertion_list(memory_ds, compression, insert_first):
@@ -119,7 +125,7 @@ def test_insertion_list(memory_ds, compression, insert_first):
         empty_sample = np.array([], dtype="object")
         if insert_first:
             ds.abc.append(first)
-        ds.abc.__setitem__(10, tenth, True)
+        ds.abc[10] = tenth
 
         if insert_first:
             np.testing.assert_array_equal(ds.abc[0].numpy(), np.array(first))

--- a/hub/api/tests/test_insertion_out_of_order.py
+++ b/hub/api/tests/test_insertion_out_of_order.py
@@ -1,0 +1,55 @@
+import numpy as np
+import pytest
+
+
+@pytest.mark.parametrize(
+    "compression",
+    [
+        {"sample_compression": None},
+        {"sample_compression": "lz4"},
+        {"chunk_compression": "lz4"},
+    ],
+)
+@pytest.mark.parametrize("insert_first", [True, False])
+def test_insertion_array(memory_ds, compression, insert_first):
+    with memory_ds as ds:
+        ds.create_tensor("abc", **compression)
+        first = np.random.rand(100, 100, 3)
+        tenth = np.random.rand(100, 100, 3)
+        empty_sample = np.random.rand(0, 0, 0)
+        if insert_first:
+            ds.abc.append(first)
+        ds.abc.__setitem__(10, tenth, True)
+
+        if insert_first:
+            np.testing.assert_array_equal(ds.abc[0].numpy(), first)
+        else:
+            np.testing.assert_array_equal(ds.abc[0].numpy(), empty_sample)
+
+        for i in range(1, 10):
+            np.testing.assert_array_equal(ds.abc[i].numpy(), empty_sample)
+        np.testing.assert_array_equal(ds.abc[10].numpy(), tenth)
+
+
+@pytest.mark.parametrize("sample_compression", ["png", "jpeg"])
+def test_insertion_array_png_jpeg(memory_ds, sample_compression):
+    with memory_ds as ds:
+        ds.create_tensor("abc", sample_compression=sample_compression)
+        first = np.random.randint(0, 256, (200, 300, 3), dtype=np.uint8)
+        tenth = np.random.randint(0, 256, (100, 100, 3), dtype=np.uint8)
+        empty_sample = np.random.randint(0, 256, (0, 0, 0), dtype=np.uint8)
+        ds.abc.append(first)
+        ds.abc.__setitem__(10, tenth, True)
+
+        if sample_compression == "png":
+            np.testing.assert_array_equal(ds.abc[0].numpy(), first)
+        else:
+            assert ds.abc[0].numpy().shape == first.shape
+
+        for i in range(1, 10):
+            np.testing.assert_array_equal(ds.abc[i].numpy(), empty_sample)
+
+        if sample_compression == "png":
+            np.testing.assert_array_equal(ds.abc[10].numpy(), tenth)
+        else:
+            assert ds.abc[10].numpy().shape == tenth.shape

--- a/hub/constants.py
+++ b/hub/constants.py
@@ -120,6 +120,7 @@ QUERIES_FILENAME = "queries.json"
 QUERIES_LOCK_FILENAME = "queries.lock"
 
 _ENABLE_HUB_SUB_DATASETS = False
+_ENABLE_RANDOM_ASSIGNMENT = False
 
 # Frequency for sending progress events and writing to vds
 QUERY_PROGRESS_UPDATE_FREQUENCY = 5  # seconds

--- a/hub/core/chunk_engine.py
+++ b/hub/core/chunk_engine.py
@@ -692,7 +692,7 @@ class ChunkEngine:
                 shape = tuple([num_samples_to_pad] + [0] * ndim)
                 dtype = self.tensor_meta.dtype
                 empty_sample = np.zeros(shape[1:], dtype=dtype)
-                empty_samples = np.zeros(shape, dtype=dtype)
+                empty_samples = np.zeros(shape, dtype=dtype)  # type: ignore
 
             if update_first_sample:
                 self.update(Index(0), empty_sample)

--- a/hub/core/chunk_engine.py
+++ b/hub/core/chunk_engine.py
@@ -680,6 +680,7 @@ class ChunkEngine:
             if self.num_samples == 0:
                 # set htype, dtype, shape, we later update it with empty sample
                 self.extend([value])
+                num_samples_to_pad -= 1
                 update_first_sample = True
 
             htype = self.tensor_meta.htype

--- a/hub/core/compression.py
+++ b/hub/core/compression.py
@@ -159,6 +159,8 @@ def compress_bytes(
     buffer: Union[bytes, memoryview], compression: Optional[str]
 ) -> bytes:
     if compression == "lz4":
+        if not buffer:
+            return b""
         return numcodecs.lz4.compress(buffer)
     else:
         raise SampleCompressionError(

--- a/hub/core/compression.py
+++ b/hub/core/compression.py
@@ -172,6 +172,9 @@ def decompress_bytes(
     if not buffer:
         return b""
     if compression == "lz4":
+        # weird edge case of lz4 + empty string
+        if buffer == b"\x00\x00\x00\x00\x00":
+            return b""
         if (
             buffer[:4] == b'\x04"M\x18'
         ):  # python-lz4 magic number (backward compatiblity)

--- a/hub/core/tensor.py
+++ b/hub/core/tensor.py
@@ -1,3 +1,4 @@
+import hub
 from hub.core.version_control.commit_chunk_set import CommitChunkSet
 from hub.core.version_control.commit_diff import CommitDiff
 from hub.core.chunk.base_chunk import InputSample
@@ -481,7 +482,7 @@ class Tensor:
         else:
             raise TypeError(f"Cannot infer numpy dtype for {val}")
 
-    def __setitem__(self, item: Union[int, slice], value: Any, pad_empty_samples=False):
+    def __setitem__(self, item: Union[int, slice], value: Any):
         """Update samples with new values.
 
         Example:
@@ -500,7 +501,11 @@ class Tensor:
             value = value.numpy(aslist=True)
         item_index = Index(item)
 
-        if pad_empty_samples and isinstance(item, int) and item >= self.num_samples:
+        if (
+            hub.constants._ENABLE_RANDOM_ASSIGNMENT
+            and isinstance(item, int)
+            and item >= self.num_samples
+        ):
             num_samples_to_pad = item - self.num_samples
             self.chunk_engine.pad_and_append(num_samples_to_pad, value)
             return

--- a/hub/core/tensor.py
+++ b/hub/core/tensor.py
@@ -481,7 +481,7 @@ class Tensor:
         else:
             raise TypeError(f"Cannot infer numpy dtype for {val}")
 
-    def __setitem__(self, item: Union[int, slice], value: Any):
+    def __setitem__(self, item: Union[int, slice], value: Any, pad_empty_samples=False):
         """Update samples with new values.
 
         Example:
@@ -499,6 +499,12 @@ class Tensor:
                 return
             value = value.numpy(aslist=True)
         item_index = Index(item)
+
+        if pad_empty_samples and isinstance(item, int) and item >= self.num_samples:
+            num_samples_to_pad = item - self.num_samples
+            self.chunk_engine.pad_and_append(num_samples_to_pad, value)
+            return
+
         self.chunk_engine.update(self.index[item_index], value)
 
     def __iter__(self):

--- a/hub/util/casting.py
+++ b/hub/util/casting.py
@@ -56,6 +56,27 @@ def get_htype(val: Union[np.ndarray, Sequence, Sample]) -> str:
     return "generic"
 
 
+def get_empty_sample(htype: str):
+    """Get an empty sample of the given htype.
+
+    Args:
+        htype: htype of the sample.
+
+    Returns:
+        Empty sample.
+    """
+    if htype == "text":
+        return ""
+    elif htype == "json":
+        return {}
+    elif htype == "list":
+        return []
+    else:
+        raise ValueError(
+            f"This method should only be used for htypes 'text', 'json' and 'list'. Got {htype}."
+        )
+
+
 def intelligent_cast(
     sample: Any, dtype: Union[np.dtype, str], htype: str
 ) -> np.ndarray:

--- a/hub/util/casting.py
+++ b/hub/util/casting.py
@@ -64,6 +64,9 @@ def get_empty_sample(htype: str):
 
     Returns:
         Empty sample.
+
+    Raises:
+        ValueError: if htype is not one of 'text', 'json', and 'list'.
     """
     if htype == "text":
         return ""


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [x]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [x]  I have commented my code, particularly in hard-to-understand areas
- [x]  I have kept the `coverage-rate` up
- [x]  I have performed a self-review of my own code and resolved any problems
- [x]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [x]  I have described and made corresponding changes to the relevant documentation
- [x]  New and existing unit tests pass locally with my changes


### Changes
- Adds the ability to setitem to a random index which lies beyond current tensor length
- Fixes a bug with empty strings + lz4 compression

Usage:-

If label tensor has 5 samples and we want to insert sample at index 10.
```python
ds.label[10] = 2  # this fails

hub.constants._ENABLE_RANDOM_ASSIGNMENT = True
ds.label[10] = 2 # works now
```