### PR TITLE
Pytorch timeout=30

### DIFF
--- a/hub/constants.py
+++ b/hub/constants.py
@@ -124,3 +124,5 @@ _ENABLE_RANDOM_ASSIGNMENT = False
 
 # Frequency for sending progress events and writing to vds
 QUERY_PROGRESS_UPDATE_FREQUENCY = 5  # seconds
+
+PYTORCH_DATALOADER_TIMEOUT = 30  # seconds

--- a/hub/integrations/pytorch/dataset.py
+++ b/hub/integrations/pytorch/dataset.py
@@ -16,6 +16,7 @@ from hub.core.io import (
     Streaming,
 )
 from hub.integrations.pytorch.shuffle_buffer import ShuffleBuffer
+from hub.constants import PYTORCH_DATALOADER_TIMEOUT
 
 import torch
 import torch.utils.data
@@ -244,7 +245,7 @@ class PrefetchConcurrentIterator(Iterable):
 
         while any(self.active_workers):
             try:
-                wid, data = self.data_queue.get(timeout=5)
+                wid, data = self.data_queue.get(timeout=PYTORCH_DATALOADER_TIMEOUT)
 
                 if isinstance(data, ExceptionWrapper):
                     data.reraise()
@@ -299,7 +300,7 @@ class PrefetchConcurrentIterator(Iterable):
             try:
                 for wid in range(self.num_workers):
                     self.request_queues[wid].put(None)
-                    self.workers[wid].join(timeout=5)
+                    self.workers[wid].join(timeout=PYTORCH_DATALOADER_TIMEOUT)
 
                 for queue in self.request_queues:
                     queue.cancel_join_thread()


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [ ]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [ ]  I have performed a self-review of my own code and resolved any problems
- [ ]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [ ]  New and existing unit tests pass locally with my changes


### Changes

Set pytorch dataloader timeout to 30 sec.

<!-- Describe your changes! Describe the scope of this PR's responsibilities. -->