### PR TITLE
add: blob htype

### DIFF
--- a/hub/core/chunk/uncompressed_chunk.py
+++ b/hub/core/chunk/uncompressed_chunk.py
@@ -81,6 +81,9 @@ class UncompressedChunk(BaseChunk):
             buffer = bytes(buffer)
             return bytes_to_text(buffer, self.htype)
         buffer = bytes(buffer) if copy else buffer
+        if self.dtype == "bytes":
+            self.tensor_meta.dtype = np.uint8
+            shape = (len(buffer),)
         return np.frombuffer(buffer, dtype=self.dtype).reshape(shape)
 
     def update_sample(self, local_index: int, sample: InputSample):

--- a/hub/core/chunk/uncompressed_chunk.py
+++ b/hub/core/chunk/uncompressed_chunk.py
@@ -83,6 +83,7 @@ class UncompressedChunk(BaseChunk):
         buffer = bytes(buffer) if copy else buffer
         if self.dtype == "bytes":
             self.tensor_meta.dtype = np.uint8
+        if np.prod(shape) != len(buffer):
             shape = (len(buffer),)
         return np.frombuffer(buffer, dtype=self.dtype).reshape(shape)
 

--- a/hub/htype.py
+++ b/hub/htype.py
@@ -21,6 +21,7 @@ Supported htypes and their respective defaults are:
 | HTYPE          |  DTYPE    |  COMPRESSION  |
 | ------------   |  -------  |  -----------  |
 | image          |  uint8    |  none         |
+| blob           |  bytes    |  none         |
 | class_label    |  uint32   |  none         |
 | bbox           |  float32  |  none         |
 | video          |  uint8    |  none         |
@@ -48,6 +49,9 @@ HTYPE_CONFIGURATIONS: Dict[str, Dict] = {
     DEFAULT_HTYPE: {"dtype": None},
     "image": {
         "dtype": "uint8",
+    },
+    "blob": {
+        "dtype": "bytes",
     },
     "class_label": {
         "dtype": "uint32",

--- a/hub/integrations/tf/datasettotensorflow.py
+++ b/hub/integrations/tf/datasettotensorflow.py
@@ -27,7 +27,10 @@ def dataset_to_tensorflow(dataset):
             corrupt_sample_found = False
             for key in dataset.tensors:
                 try:
-                    value = dataset[key][index].numpy()
+                    if dataset[key].meta.htype == "blob":
+                        value = dataset[key][index].tobytes()
+                    else:
+                        value = dataset[key][index].numpy()
                     sample[key] = value
                 except SampleDecompressionError:
                     warnings.warn(
@@ -44,6 +47,9 @@ def dataset_to_tensorflow(dataset):
             shape = dataset[key].shape
             if dtype == "str":
                 dtype = tf.string
+            if dtype == "bytes":
+                dtype = tf.string
+                shape = (None,)
             signature[key] = tf.TensorSpec(shape=shape[1:], dtype=dtype)
         return signature
 


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [ ]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [ ]  I have performed a self-review of my own code and resolved any problems
- [ ]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [ ]  New and existing unit tests pass locally with my changes


### Changes

I would like to have this blob htype for cases when I wish to keep the blob untouched on hub and defer possible decoding and such to the client. If there is already a way to achieve this, please point it out to me and this might be superfluous.