### PR TITLE
[AL-1710] Allow branch creation when dataset is locked

### DIFF
--- a/hub/api/tests/test_api.py
+++ b/hub/api/tests/test_api.py
@@ -22,6 +22,7 @@ from hub.util.exceptions import (
     InvalidTensorNameError,
     PathNotEmptyException,
     BadRequestException,
+    ReadOnlyModeError,
 )
 from hub.constants import MB
 
@@ -1396,3 +1397,13 @@ def test_pyav_not_installed(local_ds, video_paths):
     with pytest.raises(hub.util.exceptions.CorruptedSampleError):
         local_ds.videos.append(hub.read(video_paths["mp4"][0]))
     hub.core.compression._PYAV_INSTALLED = pyav_installed
+
+
+def test_create_branch_when_locked_out(local_ds):
+    local_ds.read_only = True
+    local_ds._locked_out = True
+    with pytest.raises(ReadOnlyModeError):
+        local_ds.create_tensor("x")
+    local_ds.checkout("branch", create=True)
+    assert local_ds.branch == "branch"
+    local_ds.create_tensor("x")

--- a/hub/core/dataset/dataset.py
+++ b/hub/core/dataset/dataset.py
@@ -842,9 +842,12 @@ class Dataset:
             raise Exception(
                 "Cannot perform version control operations on a filtered dataset view."
             )
-
+        if self._locked_out:
+            self.storage.disable_readonly()
+            self._read_only = False
+            base_storage = get_base_storage(self.storage)
+            base_storage.disable_readonly()
         try_flushing(self)
-
         self._initial_autoflush.append(self.storage.autoflush)
         self.storage.autoflush = False
         try:

--- a/hub/core/dataset/dataset.py
+++ b/hub/core/dataset/dataset.py
@@ -850,19 +850,20 @@ class Dataset:
         try_flushing(self)
         self._initial_autoflush.append(self.storage.autoflush)
         self.storage.autoflush = False
+        err = False
         try:
             self._unlock()
             checkout(self, address, create, hash)
-            self._lock()
         except Exception as e:
+            err = True
             if self._locked_out:
                 self.storage.enable_readonly()
                 self._read_only = True
                 base_storage.enable_readonly()
-            else:
-                self._lock()
             raise e
         finally:
+            if not (err and self._locked_out):
+                self._lock()
             self.storage.autoflush = self._initial_autoflush.pop()
         self._info = None
         self._ds_diff = None

--- a/hub/core/dataset/dataset.py
+++ b/hub/core/dataset/dataset.py
@@ -854,6 +854,14 @@ class Dataset:
             self._unlock()
             checkout(self, address, create, hash)
             self._lock()
+        except Exception as e:
+            if self._locked_out:
+                self.storage.enable_readonly()
+                self._read_only = True
+                base_storage.enable_readonly()
+            else:
+                self._lock()
+            raise e
         finally:
             self.storage.autoflush = self._initial_autoflush.pop()
         self._info = None


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [ ]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [ ]  I have performed a self-review of my own code and resolved any problems
- [ ]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [ ]  New and existing unit tests pass locally with my changes


### Changes

Allow creating branch even if dataset is locked by another user.
<!-- Describe your changes! Describe the scope of this PR's responsibilities. -->