### PR TITLE
Fixed reading from remote url #1546

### DIFF
--- a/hub/core/sample.py
+++ b/hub/core/sample.py
@@ -310,7 +310,10 @@ class Sample:
                         )
                     self._uncompressed_bytes = self._array.tobytes()
                 else:
-                    img = Image.open(self.path)
+                    if self.path.startswith("http"):
+                        img = Image.open(urlopen(self.path))
+                    else:
+                        img = Image.open(self.path)
                     if img.mode == "1":
                         # Binary images need to be extended from bits to bytes
                         self._uncompressed_bytes = img.tobytes("raw", "L")


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [X]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [X]  I have commented my code, particularly in hard-to-understand areas
- [X]  I have kept the `coverage-rate` up
- [X]  I have performed a self-review of my own code and resolved any problems
- [X]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [X]  New and existing unit tests pass locally with my changes


### Changes

Added a check if the path to an image is a remote url, which then reads it using urlopen and loads the image. Otherwise it reads the image as usual.

Fixes bug mentioned [here.](https://github.com/activeloopai/Hub/issues/1546)