### PR TITLE
Move pretty printing from __str__ to summary()

### DIFF
--- a/hub/api/tests/test_api.py
+++ b/hub/api/tests/test_api.py
@@ -165,26 +165,30 @@ def test_larger_data_memory(memory_ds):
         np.testing.assert_array_equal(memory_ds.image[idx].numpy(), x[idx])
 
 
-def test_stringify(memory_ds):
+def test_stringify(memory_ds, capsys):
     ds = memory_ds
     ds.create_tensor("image")
     ds.image.extend(np.ones((4, 4)))
 
+    ds.summary()
     assert (
-        str(ds)
-        == "Dataset(path='mem://hub_pytest/test_api/test_stringify', tensors=['image'])\n\n tensor    htype    shape    dtype  compression\n -------  -------  -------  -------  ------- \n  image   generic  (4, 4)    None     None   "
+        capsys.readouterr().out
+        == "Dataset(path='mem://hub_pytest/test_api/test_stringify', tensors=['image'])\n\n tensor    htype    shape    dtype  compression\n -------  -------  -------  -------  ------- \n  image   generic  (4, 4)    None     None   \n"
     )
+    ds[1:2].summary()
     assert (
-        str(ds[1:2])
-        == "Dataset(path='mem://hub_pytest/test_api/test_stringify', index=Index([slice(1, 2, None)]), tensors=['image'])\n\n tensor    htype    shape    dtype  compression\n -------  -------  -------  -------  ------- \n  image   generic  (1, 4)    None     None   "
+        capsys.readouterr().out
+        == "Dataset(path='mem://hub_pytest/test_api/test_stringify', index=Index([slice(1, 2, None)]), tensors=['image'])\n\n tensor    htype    shape    dtype  compression\n -------  -------  -------  -------  ------- \n  image   generic  (1, 4)    None     None   \n"
     )
+    ds.image.summary()
     assert (
-        str(ds.image)
-        == "Tensor(key='image')\n\n tensor    htype    shape    dtype  compression\n -------  -------  -------  -------  ------- \n  image   generic  (4, 4)    None     None   "
+        capsys.readouterr().out
+        == "Tensor(key='image')\n\n  htype    shape    dtype  compression\n -------  -------  -------  ------- \n generic  (4, 4)    None     None   \n"
     )
+    ds[1:2].image.summary()
     assert (
-        str(ds[1:2].image)
-        == "Tensor(key='image', index=Index([slice(1, 2, None)]))\n\n tensor    htype    shape    dtype  compression\n -------  -------  -------  -------  ------- \n  image   generic  (1, 4)    None     None   "
+        capsys.readouterr().out
+        == "Tensor(key='image', index=Index([slice(1, 2, None)]))\n\n  htype    shape    dtype  compression\n -------  -------  -------  ------- \n generic  (1, 4)    None     None   \n"
     )
 
 
@@ -200,20 +204,21 @@ def test_summary(memory_ds):
     )
     assert (
         summary_tensor(ds.abc)
-        == "\n tensor    htype    shape    dtype  compression\n -------  -------  -------  -------  ------- \n   abc    generic  (4, 4)    None     None   "
+        == "\n  htype    shape    dtype  compression\n -------  -------  -------  ------- \n generic  (4, 4)    None     None   "
     )
     assert (
         summary_tensor(ds.images)
-        == "\n tensor    htype    shape    dtype  compression\n -------  -------  -------  -------  ------- \n images    image    (0,)     int32    jpeg   "
+        == "\n  htype    shape    dtype  compression\n -------  -------  -------  ------- \n  image    (0,)     int32    jpeg   "
     )
 
 
-def test_stringify_with_path(local_ds):
+def test_stringify_with_path(local_ds, capsys):
     ds = local_ds
     assert local_ds.path
+    ds.summary()
     assert (
-        str(ds)
-        == f"Dataset(path='{local_ds.path}', tensors=[])\n\n tensor    htype    shape    dtype  compression\n -------  -------  -------  -------  ------- "
+        capsys.readouterr().out
+        == f"Dataset(path='{local_ds.path}', tensors=[])\n\n tensor    htype    shape    dtype  compression\n -------  -------  -------  -------  ------- \n"
     )
 
 

--- a/hub/core/dataset/dataset.py
+++ b/hub/core/dataset/dataset.py
@@ -1305,10 +1305,13 @@ class Dataset:
         self._unlock()
         self.storage.clear()
 
-    def __str__(self):
-
+    def summary(self):
         pretty_print = summary_dataset(self)
 
+        print(self)
+        print(pretty_print)
+
+    def __str__(self):
         path_str = ""
         if self.path:
             path_str = f"path='{self.path}', "
@@ -1325,11 +1328,7 @@ class Dataset:
             f"group_index='{self.group_index}', " if self.group_index else ""
         )
 
-        return (
-            f"Dataset({path_str}{mode_str}{index_str}{group_index_str}tensors={self._all_tensors_filtered(include_hidden=False)})"
-            + "\n"
-            + pretty_print
-        )
+        return f"Dataset({path_str}{mode_str}{index_str}{group_index_str}tensors={self._all_tensors_filtered(include_hidden=False)})"
 
     __repr__ = __str__
 

--- a/hub/core/tensor.py
+++ b/hub/core/tensor.py
@@ -589,14 +589,18 @@ class Tensor:
 
         return self.chunk_engine.numpy(self.index, aslist=aslist)
 
+    def summary(self):
+        pretty_print = summary_tensor(self)
+
+        print(self)
+        print(pretty_print)
+        
+    
     def __str__(self):
         index_str = f", index={self.index}"
         if self.index.is_trivial():
             index_str = ""
-        pretty_print = summary_tensor(
-            self
-        )  # get the string for table format of the tensors
-        return f"Tensor(key={repr(self.key)}{index_str})" + "\n" + pretty_print
+        return f"Tensor(key={repr(self.key)}{index_str})"
 
     __repr__ = __str__
 

--- a/hub/core/tensor.py
+++ b/hub/core/tensor.py
@@ -594,8 +594,7 @@ class Tensor:
 
         print(self)
         print(pretty_print)
-        
-    
+
     def __str__(self):
         index_str = f", index={self.index}"
         if self.index.is_trivial():

--- a/hub/util/pretty_print.py
+++ b/hub/util/pretty_print.py
@@ -26,14 +26,13 @@ def get_string(
 
 def summary_tensor(tensor):
     head = [
-        "tensor",
         "htype",
         "shape",
         "dtype",
         "compression",
     ]
-    divider = ["-------"] * 5
-    max_column_length = [7, 7, 7, 7, 7]
+    divider = ["-------"] * 4
+    max_column_length = [7, 7, 7, 7]
 
     tensor_htype = tensor.htype
     if tensor_htype == None:
@@ -54,7 +53,6 @@ def summary_tensor(tensor):
         head,
         divider,
         [
-            str(tensor.key),
             tensor_htype,
             tensor_shape,
             tensor_dtype,
@@ -64,7 +62,7 @@ def summary_tensor(tensor):
     # adding information about tensors
     max_column_length = max_array_length(
         max_column_length, self_array[2]
-    )  # 3rd element of slefarray corresponds to tensor att
+    )  # 3rd element of self_array corresponds to tensor att
     max_column_length = [elem + 2 for elem in max_column_length]
     return get_string(self_array, max_column_length)
 


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [ ]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [ ]  I have performed a self-review of my own code and resolved any problems
- [ ]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [ ]  New and existing unit tests pass locally with my changes


### Changes
Pretty printing should be done only when `ds.summary()` or `tensor.summary()` is called

<!-- Describe your changes! Describe the scope of this PR's responsibilities. -->