### PR TITLE
[AL-1749] image.rgb and image.gray htypes

### DIFF
--- a/hub/api/tests/test_api.py
+++ b/hub/api/tests/test_api.py
@@ -936,6 +936,8 @@ def test_htypes_list():
         "dicom",
         "generic",
         "image",
+        "image.gray",
+        "image.rgb",
         "json",
         "keypoints_coco",
         "list",

--- a/hub/api/tests/test_api_with_compression.py
+++ b/hub/api/tests/test_api_with_compression.py
@@ -269,3 +269,32 @@ def test_exif(memory_ds, compressed_image_paths):
             type(image.sample_info["exif"]),
             path,
         )
+
+
+def test_forced_htypes(memory_ds, grayscale_image_paths, color_image_paths):
+    with memory_ds as ds:
+        gray = ds.create_tensor("gray", htype="image.gray", sample_compression="jpeg")
+        rgb = ds.create_tensor("rgb", htype="image.rgb", sample_compression="jpeg")
+
+        ds.gray.append(hub.read(grayscale_image_paths["jpeg"]))
+        ds.gray.append(hub.read(color_image_paths["jpeg"]))
+        ds.gray.extend(np.ones((4, 10, 10, 3), dtype=np.uint8))
+        ds.gray.extend(
+            [hub.read(color_image_paths["jpeg"]), np.ones((10, 10), dtype=np.uint8)]
+        )
+
+        ds.rgb.append(hub.read(grayscale_image_paths["jpeg"]))
+        ds.rgb.append(hub.read(color_image_paths["jpeg"]))
+        ds.rgb.extend(np.ones((4, 10, 10), dtype=np.uint8))
+        ds.rgb.extend(
+            [
+                hub.read(grayscale_image_paths["jpeg"]),
+                np.ones((10, 10, 3), dtype=np.uint8),
+            ]
+        )
+
+    for sample in gray:
+        assert len(sample.shape) == 2
+
+    for sample in rgb:
+        assert len(sample.shape) == 3

--- a/hub/api/tests/test_api_with_compression.py
+++ b/hub/api/tests/test_api_with_compression.py
@@ -271,7 +271,9 @@ def test_exif(memory_ds, compressed_image_paths):
         )
 
 
-def test_forced_htypes(memory_ds, grayscale_image_paths, color_image_paths):
+def test_forced_htypes(
+    memory_ds, grayscale_image_paths, color_image_paths, flower_path
+):
     with memory_ds as ds:
         gray = ds.create_tensor("gray", htype="image.gray", sample_compression="jpeg")
         rgb = ds.create_tensor("rgb", htype="image.rgb", sample_compression="jpeg")
@@ -293,8 +295,27 @@ def test_forced_htypes(memory_ds, grayscale_image_paths, color_image_paths):
             ]
         )
 
+        gray_png = ds.create_tensor(
+            "gray_png", htype="image.gray", sample_compression="png"
+        )
+        rgb_png = ds.create_tensor(
+            "rgb_png", htype="image.rgb", sample_compression="png"
+        )
+
+        gray_png.append(hub.read(flower_path))
+        gray_png.append(np.ones((10, 10, 4), dtype=np.uint8))
+
+        rgb_png.append(hub.read(flower_path))
+        rgb_png.append(np.ones((10, 10, 4), dtype=np.uint8))
+
     for sample in gray:
         assert len(sample.shape) == 2
 
     for sample in rgb:
+        assert len(sample.shape) == 3
+
+    for sample in gray_png:
+        assert len(sample.shape) == 2
+
+    for sample in rgb_png:
         assert len(sample.shape) == 3

--- a/hub/core/chunk_engine.py
+++ b/hub/core/chunk_engine.py
@@ -49,7 +49,9 @@ from hub.util.exceptions import (
     ReadOnlyModeError,
 )
 from hub.util.remove_cache import get_base_storage
+from hub.util.image import convert_sample, convert_img_arr
 from hub.compression import VIDEO_COMPRESSIONS
+from hub.core.sample import Sample
 from itertools import chain, repeat
 from collections.abc import Iterable
 
@@ -556,6 +558,15 @@ class ChunkEngine:
             tensor_meta.set_dtype(get_dtype(samples))
         if self._convert_to_list(samples):
             samples = list(samples)
+        if tensor_meta.htype in ("image.gray", "image.rgb"):
+            mode = "L" if tensor_meta.htype == "image.gray" else "RGB"
+            converted = []
+            for sample in samples:
+                if isinstance(sample, Sample):
+                    converted.append(convert_sample(sample, mode, self.compression))
+                elif isinstance(sample, np.ndarray):
+                    converted.append(convert_img_arr(sample, mode))
+            samples = verified_samples = converted
         return samples, verified_samples
 
     def _samples_to_chunks(

--- a/hub/core/serialize.py
+++ b/hub/core/serialize.py
@@ -18,6 +18,7 @@ import numpy as np
 import struct
 import json
 from urllib.request import Request, urlopen
+from hub.util.image import convert_sample
 
 BaseTypes = Union[np.ndarray, list, int, float, bool, np.integer, np.floating, np.bool_]
 
@@ -442,6 +443,12 @@ def serialize_sample_object(
             # Byte compressions don't store dtype, need to cast to expected dtype
             arr = intelligent_cast(out.array, dtype, htype)
             out = Sample(array=arr)
+        elif htype == "image.rgb":
+            out = convert_sample(out, "RGB", sample_compression)
+            shape = out.shape
+        elif htype == "image.gray":
+            out = convert_sample(out, "L", sample_compression)
+            shape = out.shape
 
         compressed_bytes = out.compressed_bytes(sample_compression)
 

--- a/hub/core/serialize.py
+++ b/hub/core/serialize.py
@@ -443,12 +443,6 @@ def serialize_sample_object(
             # Byte compressions don't store dtype, need to cast to expected dtype
             arr = intelligent_cast(out.array, dtype, htype)
             out = Sample(array=arr)
-        elif htype == "image.rgb":
-            out = convert_sample(out, "RGB", sample_compression)
-            shape = out.shape
-        elif htype == "image.gray":
-            out = convert_sample(out, "L", sample_compression)
-            shape = out.shape
 
         compressed_bytes = out.compressed_bytes(sample_compression)
 

--- a/hub/core/serialize.py
+++ b/hub/core/serialize.py
@@ -18,7 +18,6 @@ import numpy as np
 import struct
 import json
 from urllib.request import Request, urlopen
-from hub.util.image import convert_sample
 
 BaseTypes = Union[np.ndarray, list, int, float, bool, np.integer, np.floating, np.bool_]
 

--- a/hub/htype.py
+++ b/hub/htype.py
@@ -56,6 +56,12 @@ HTYPE_CONFIGURATIONS: Dict[str, Dict] = {
     "image": {
         "dtype": "uint8",
     },
+    "image.rgb": {
+        "dtype": "uint8",
+    },
+    "image.gray": {
+        "dtype": "uint8",
+    },
     "class_label": {
         "dtype": "uint32",
         "class_names": [],
@@ -81,11 +87,15 @@ HTYPE_VERIFICATIONS: Dict[str, Dict] = {
     "bbox": {"coords": {"type": dict, "keys": ["type", "mode"]}}
 }
 
-_image_compressions = IMAGE_COMPRESSIONS[:]
+_image_compressions = (
+    IMAGE_COMPRESSIONS[:] + BYTE_COMPRESSIONS + list(COMPRESSION_ALIASES)
+)
 _image_compressions.remove("dcm")
 
 HTYPE_SUPPORTED_COMPRESSIONS = {
-    "image": _image_compressions + BYTE_COMPRESSIONS + list(COMPRESSION_ALIASES),
+    "image": _image_compressions,
+    "image.rgb": _image_compressions,
+    "image.gray": _image_compressions,
     "video": VIDEO_COMPRESSIONS[:],
     "audio": AUDIO_COMPRESSIONS[:],
     "text": BYTE_COMPRESSIONS[:],

--- a/hub/util/image.py
+++ b/hub/util/image.py
@@ -42,8 +42,10 @@ def convert_img_arr(image_arr: np.ndarray, mode: str) -> np.ndarray:
         elif mode == "RGB":
             return image_arr[:, :, :3]
 
-    if (image_arr.shape[-1]) == 3:
+    elif (image_arr.shape[-1]) == 3:
         if mode == "L":
             return to_grayscale(image_arr)
         elif mode == "RGB":
             return image_arr
+
+    raise ValueError("Invalid image")

--- a/hub/util/image.py
+++ b/hub/util/image.py
@@ -1,6 +1,7 @@
 from io import BytesIO
 from PIL import Image  # type: ignore
 from hub.core.sample import Sample
+import numpy as np
 
 
 def convert_sample(image_sample: Sample, mode: str, compression: str) -> Sample:
@@ -9,6 +10,7 @@ def convert_sample(image_sample: Sample, mode: str, compression: str) -> Sample:
     elif image_sample._buffer:
         image = Image.open(BytesIO(image_sample._buffer))
     if image.mode == mode:
+        image.close()
         return image_sample
 
     image = image.convert(mode)
@@ -17,4 +19,31 @@ def convert_sample(image_sample: Sample, mode: str, compression: str) -> Sample:
     converted = Sample(
         buffer=image_bytes.getvalue(), compression=image_sample.compression
     )
+    image.close()
     return converted
+
+
+def to_grayscale(arr: np.ndarray) -> np.ndarray:
+    transform = np.array([[[299 / 1000, 587 / 1000, 114 / 1000]]])
+    gray = np.sum(transform * arr[:, :, :3], axis=2, dtype=np.uint8)
+    return gray
+
+
+def convert_img_arr(image_arr: np.ndarray, mode: str) -> np.ndarray:
+    if len(image_arr.shape) == 2:
+        if mode == "L":
+            return image_arr
+        elif mode == "RGB":
+            return np.tile(image_arr[:, :, np.newaxis], (1, 1, 3))
+
+    if (image_arr.shape[-1]) == 4:
+        if mode == "L":
+            return to_grayscale(image_arr)
+        elif mode == "RGB":
+            return image_arr[:, :, :3]
+
+    if (image_arr.shape[-1]) == 3:
+        if mode == "L":
+            return to_grayscale(image_arr)
+        elif mode == "RGB":
+            return image_arr

--- a/hub/util/image.py
+++ b/hub/util/image.py
@@ -1,0 +1,20 @@
+from io import BytesIO
+from PIL import Image  # type: ignore
+from hub.core.sample import Sample
+
+
+def convert_sample(image_sample: Sample, mode: str, compression: str) -> Sample:
+    if image_sample.path:
+        image = Image.open(image_sample.path)
+    elif image_sample._buffer:
+        image = Image.open(BytesIO(image_sample._buffer))
+    if image.mode == mode:
+        return image_sample
+
+    image = image.convert(mode)
+    image_bytes = BytesIO()
+    image.save(image_bytes, format=compression)
+    converted = Sample(
+        buffer=image_bytes.getvalue(), compression=image_sample.compression
+    )
+    return converted


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [ ]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [ ]  I have performed a self-review of my own code and resolved any problems
- [ ]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [ ]  New and existing unit tests pass locally with my changes


### Changes
Added new htypes `image.rgb` and `image.gray`
<!-- Describe your changes! Describe the scope of this PR's responsibilities. -->