### PR TITLE
[BUG] Image htypes fix for recompression

### DIFF
--- a/hub/api/tests/test_api_with_compression.py
+++ b/hub/api/tests/test_api_with_compression.py
@@ -279,17 +279,19 @@ def test_forced_htypes(
         gray = ds.create_tensor("gray", htype="image.gray", sample_compression="jpeg")
         rgb = ds.create_tensor("rgb", htype="image.rgb", sample_compression="jpeg")
 
-        ds.gray.append(hub.read(grayscale_image_paths["jpeg"]))
-        ds.gray.append(hub.read(color_image_paths["jpeg"]))
-        ds.gray.extend(np.ones((4, 10, 10, 3), dtype=np.uint8))
-        ds.gray.extend(
+        gray.append(hub.read(grayscale_image_paths["jpeg"]))
+        gray.append(hub.read(color_image_paths["jpeg"]))
+        gray.append(hub.read(flower_path))
+        gray.extend(np.ones((4, 10, 10, 3), dtype=np.uint8))
+        gray.extend(
             [hub.read(color_image_paths["jpeg"]), np.ones((10, 10), dtype=np.uint8)]
         )
 
-        ds.rgb.append(hub.read(grayscale_image_paths["jpeg"]))
-        ds.rgb.append(hub.read(color_image_paths["jpeg"]))
-        ds.rgb.extend(np.ones((4, 10, 10), dtype=np.uint8))
-        ds.rgb.extend(
+        rgb.append(hub.read(grayscale_image_paths["jpeg"]))
+        rgb.append(hub.read(color_image_paths["jpeg"]))
+        rgb.append(hub.read(flower_path))
+        rgb.extend(np.ones((4, 10, 10), dtype=np.uint8))
+        rgb.extend(
             [
                 hub.read(grayscale_image_paths["jpeg"]),
                 np.ones((10, 10, 3), dtype=np.uint8),

--- a/hub/core/chunk_engine.py
+++ b/hub/core/chunk_engine.py
@@ -585,7 +585,7 @@ class ChunkEngine:
             converted = []
             for sample in samples:
                 if isinstance(sample, Sample):
-                    converted.append(convert_sample(sample, mode, self.compression))
+                    converted.append(convert_sample(sample, mode))
                 elif isinstance(sample, np.ndarray):
                     converted.append(convert_img_arr(sample, mode))
                 else:

--- a/hub/util/image.py
+++ b/hub/util/image.py
@@ -4,7 +4,7 @@ from hub.core.sample import Sample
 import numpy as np
 
 
-def convert_sample(image_sample: Sample, mode: str, compression: str) -> Sample:
+def convert_sample(image_sample: Sample, mode: str) -> Sample:
     if image_sample.path:
         image = Image.open(image_sample.path)
     elif image_sample._buffer:
@@ -15,7 +15,7 @@ def convert_sample(image_sample: Sample, mode: str, compression: str) -> Sample:
 
     image = image.convert(mode)
     image_bytes = BytesIO()
-    image.save(image_bytes, format=compression)
+    image.save(image_bytes, format=image_sample.compression)
     converted = Sample(
         buffer=image_bytes.getvalue(), compression=image_sample.compression
     )


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [ ]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [ ]  I have performed a self-review of my own code and resolved any problems
- [ ]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [ ]  New and existing unit tests pass locally with my changes


### Changes
Fix case when recompressing image with `image.rgb` or `image.gray` htypes.
<!-- Describe your changes! Describe the scope of this PR's responsibilities. -->