### PR TITLE
[small] Remove files created during test_rechunk

### DIFF
--- a/hub/api/tests/test_rechunk.py
+++ b/hub/api/tests/test_rechunk.py
@@ -1,6 +1,7 @@
 import numpy as np
 import random
 import hub
+from click.testing import CliRunner
 
 
 def test_rechunk(local_ds):
@@ -69,15 +70,16 @@ def test_rechunk_2(local_ds):
 
 
 def test_rechunk_3():
-    NUM_TEST_SAMPLES = 100
-    hub.constants._ENABLE_RANDOM_ASSIGNMENT = True
-    test_sample = np.random.randint(0, 255, size=(600, 600, 3), dtype=np.uint8)
-    dataset_path = r"local/path"
-    ds = hub.empty(dataset_path, overwrite=True)
-    ds.create_tensor("test", dtype="uint8")
-    r = list(range(NUM_TEST_SAMPLES))
-    random.seed(20)
-    random.shuffle(r)
-    with ds:
-        for i in r:
-            ds.test[i] = test_sample
+    with CliRunner().isolated_filesystem():
+        NUM_TEST_SAMPLES = 100
+        hub.constants._ENABLE_RANDOM_ASSIGNMENT = True
+        test_sample = np.random.randint(0, 255, size=(600, 600, 3), dtype=np.uint8)
+        dataset_path = r"local/path"
+        ds = hub.empty(dataset_path, overwrite=True)
+        ds.create_tensor("test", dtype="uint8")
+        r = list(range(NUM_TEST_SAMPLES))
+        random.seed(20)
+        random.shuffle(r)
+        with ds:
+            for i in r:
+                ds.test[i] = test_sample

--- a/hub/api/tests/test_rechunk.py
+++ b/hub/api/tests/test_rechunk.py
@@ -1,7 +1,6 @@
 import numpy as np
 import random
 import hub
-from click.testing import CliRunner
 
 
 def test_rechunk(local_ds):
@@ -69,17 +68,14 @@ def test_rechunk_2(local_ds):
         assert ds.compr.chunk_engine.num_chunks == 1
 
 
-def test_rechunk_3():
-    with CliRunner().isolated_filesystem():
-        NUM_TEST_SAMPLES = 100
-        hub.constants._ENABLE_RANDOM_ASSIGNMENT = True
-        test_sample = np.random.randint(0, 255, size=(600, 600, 3), dtype=np.uint8)
-        dataset_path = r"local/path"
-        ds = hub.empty(dataset_path, overwrite=True)
+def test_rechunk_3(local_ds):
+    NUM_TEST_SAMPLES = 100
+    hub.constants._ENABLE_RANDOM_ASSIGNMENT = True
+    test_sample = np.random.randint(0, 255, size=(600, 600, 3), dtype=np.uint8)
+    with local_ds as ds:
         ds.create_tensor("test", dtype="uint8")
         r = list(range(NUM_TEST_SAMPLES))
         random.seed(20)
         random.shuffle(r)
-        with ds:
-            for i in r:
-                ds.test[i] = test_sample
+        for i in r:
+            ds.test[i] = test_sample


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [X]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [X]  I have performed a self-review of my own code and resolved any problems
- [X]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [X]  I have described and made corresponding changes to the relevant documentation
- [X]  New and existing unit tests pass locally with my changes


### Changes
While running pytest to check if unit tests pass, a dataset is being created locally every time `test_rechunk_3` in `test_rechunk.py` was run. This PR uses `CliRunner().isolated_filesystem()` to make sure those local files are deleted after the test passes.
<!-- Describe your changes! Describe the scope of this PR's responsibilities. -->