### PR TITLE
[AL-1805] Version control + linked tensor bug

### DIFF
--- a/hub/api/tests/test_link.py
+++ b/hub/api/tests/test_link.py
@@ -201,6 +201,8 @@ def test_basic(local_ds_generator, cat_path, flower_path, create_shape_tensor, v
             sample = hub.link(flower_path)
             ds.linked_images.append(sample)
 
+        ds.commit()
+
         ds.linked_images.append(None)
 
         for i in range(0, 10, 2):

--- a/hub/util/version_control.py
+++ b/hub/util/version_control.py
@@ -18,6 +18,7 @@ from hub.core.lock import Lock
 from hub.util.exceptions import CheckoutError, CommitError
 from hub.util.keys import (
     get_chunk_id_encoder_key,
+    get_creds_encoder_key,
     get_sequence_encoder_key,
     get_dataset_diff_key,
     get_dataset_info_key,
@@ -253,6 +254,15 @@ def copy_metas(
             src_sequence_encoder = storage[src_sequence_encoder_key]
             dest_sequence_encoder = convert_to_bytes(src_sequence_encoder)
             storage[dest_sequence_encoder_key] = dest_sequence_encoder
+        except KeyError:
+            pass
+
+        try:
+            src_creds_encoder_key = get_creds_encoder_key(tensor, src_commit_id)
+            dest_creds_encoder_key = get_creds_encoder_key(tensor, dest_commit_id)
+            src_creds_encoder = storage[src_creds_encoder_key]
+            dest_creds_encoder = convert_to_bytes(src_creds_encoder)
+            storage[dest_creds_encoder_key] = dest_creds_encoder
         except KeyError:
             pass
 


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [ ]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [ ]  I have performed a self-review of my own code and resolved any problems
- [ ]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [ ]  New and existing unit tests pass locally with my changes


### Changes

Test fails after adding ds.commit()


```
hub\api\tests\test_link.py F

====================================================== FAILURES =======================================================
________________________________________________ test_basic[True-True] ________________________________________________

local_ds_generator = <function local_ds_generator.<locals>.generate_local_ds at 0x000002C4F9766DC0>
cat_path = 'C:\\Users\\fariz\\code\\hub\\hub\\tests\\dummy_data\\images\\cat.jpeg'
flower_path = 'C:\\Users\\fariz\\code\\hub\\hub\\tests\\dummy_data\\images\\flower.png', create_shape_tensor = True
verify = True

    @pytest.mark.parametrize("create_shape_tensor", [True, False])
    @pytest.mark.parametrize("verify", [True, False])
    def test_basic(local_ds_generator, cat_path, flower_path, create_shape_tensor, verify):
        local_ds = local_ds_generator()
        with local_ds as ds:
            ds.create_tensor(
                "linked_images",
                htype="link[image]",
                create_shape_tensor=create_shape_tensor,
                verify=verify,
                sample_compression="jpeg",
            )
            with pytest.raises(TypeError):
                ds.linked_images.append(np.ones((100, 100, 3)))

            for _ in range(10):
                sample = hub.link(flower_path)
                ds.linked_images.append(sample)

            ds.commit()

            ds.linked_images.append(None)

            for i in range(0, 10, 2):
                sample = hub.link(cat_path)
>               ds.linked_images[i] = sample

hub\api\tests\test_link.py:210:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
hub\core\tensor.py:632: in __setitem__
    self.chunk_engine.update(
hub\core\chunk_engine.py:915: in update
    (self._sequence_update if self.is_sequence else self._update)(  # type: ignore
hub\core\chunk_engine.py:1153: in _update
    self.update_creds(global_sample_index, sample)
hub\core\linked_chunk_engine.py:167: in update_creds
    self.creds_encoder[sample_index] = (encoded_creds_key,)
hub\core\meta\encode\creds.py:22: in __setitem__
    return super().__setitem__(local_sample_index, item)
hub\core\meta\encode\base_encoder.py:305: in __setitem__
    if action(item, row_index, local_sample_index):  # type: ignore
hub\core\meta\encode\base_encoder.py:376: in _try_not_changing
    return self._combine_condition(item, row_index)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <hub.core.meta.encode.creds.CredsEncoder object at 0x000002C4F97E9550>, shape = (0,), compare_row_index = 1

    def _combine_condition(
        self, shape: Tuple[int], compare_row_index: int = -1
    ) -> bool:
>       last_shape = self._derive_value(self._encoded[compare_row_index])
E       IndexError: index 1 is out of bounds for axis 0 with size 1

hub\core\meta\encode\shape.py:30: IndexError
```

<!-- Describe your changes! Describe the scope of this PR's responsibilities. -->