### PR TITLE
[AL-1790] Adds ability to return indexes in pytorch

### DIFF
--- a/hub/core/dataset/dataset.py
+++ b/hub/core/dataset/dataset.py
@@ -1350,7 +1350,7 @@ class Dataset:
             buffer_size (int): The size of the buffer used to shuffle the data in MBs. Defaults to 2048 MB. Increasing the buffer_size will increase the extent of shuffling.
             use_local_cache (bool): If True, the data loader will use a local cache to store data. This is useful when the dataset can fit on the machine and we don't want to fetch the data multiple times for each iteration. Default value is False.
             use_progress_bar (bool): If True, tqdm will be wrapped around the returned dataloader. Default value is True.
-            return_index (bool): If True, the returned dataloader will return a have a key "index" that contains the index of the sample(s) in the original dataset. Default value is False.
+            return_index (bool): If True, the returned dataloader will have a key "index" that contains the index of the sample(s) in the original dataset. Default value is False.
 
         Returns:
             A torch.utils.data.DataLoader object.

--- a/hub/core/dataset/dataset.py
+++ b/hub/core/dataset/dataset.py
@@ -1325,6 +1325,7 @@ class Dataset:
         buffer_size: int = 2048,
         use_local_cache: bool = False,
         use_progress_bar: bool = False,
+        return_index: bool = False,
     ):
         """Converts the dataset into a pytorch Dataloader.
 
@@ -1349,6 +1350,7 @@ class Dataset:
             buffer_size (int): The size of the buffer used to shuffle the data in MBs. Defaults to 2048 MB. Increasing the buffer_size will increase the extent of shuffling.
             use_local_cache (bool): If True, the data loader will use a local cache to store data. This is useful when the dataset can fit on the machine and we don't want to fetch the data multiple times for each iteration. Default value is False.
             use_progress_bar (bool): If True, tqdm will be wrapped around the returned dataloader. Default value is True.
+            return_index (bool): If True, the returned dataloader will return a have a key "index" that contains the index of the sample(s) in the original dataset. Default value is False.
 
         Returns:
             A torch.utils.data.DataLoader object.
@@ -1368,6 +1370,7 @@ class Dataset:
             shuffle=shuffle,
             buffer_size=buffer_size,
             use_local_cache=use_local_cache,
+            return_index=return_index,
         )
 
         if use_progress_bar:

--- a/hub/core/io.py
+++ b/hub/core/io.py
@@ -7,6 +7,7 @@ from warnings import warn
 from numpy import nditer, argmin
 from numpy import array as nparray
 from math import floor
+import numpy as np
 
 
 from hub.constants import MB
@@ -254,6 +255,7 @@ class SampleStreaming(Streaming):
         tensors: Sequence[str],
         tobytes: Union[bool, Sequence[str]] = False,
         use_local_cache: bool = False,
+        return_index: bool = False,
     ) -> None:
         super().__init__()
 
@@ -287,6 +289,8 @@ class SampleStreaming(Streaming):
             if self.local_storage is not None
             else None
         )
+
+        self.return_index = return_index
 
     def read(self, schedule: Schedule) -> Iterator:
         for block in schedule._blocks:
@@ -353,6 +357,8 @@ class SampleStreaming(Streaming):
                     break
 
             if valid_sample_flag:
+                if self.return_index:
+                    sample["index"] = np.array([idx])
                 yield sample
 
     def list_blocks(self) -> List[IOBlock]:

--- a/hub/integrations/pytorch/dataset.py
+++ b/hub/integrations/pytorch/dataset.py
@@ -216,7 +216,6 @@ class PrefetchConcurrentIterator(Iterable):
         self.dataset = dataset
         self.num_workers = dataset.num_workers
         self.buffer_size = dataset.buffer_size
-        self.return_index = dataset.return_index
         self.prefetch = 64
 
         self.workers: List[Process] = []

--- a/hub/integrations/pytorch/dataset.py
+++ b/hub/integrations/pytorch/dataset.py
@@ -216,6 +216,7 @@ class PrefetchConcurrentIterator(Iterable):
         self.dataset = dataset
         self.num_workers = dataset.num_workers
         self.buffer_size = dataset.buffer_size
+        self.return_index = dataset.return_index
         self.prefetch = 64
 
         self.workers: List[Process] = []
@@ -408,6 +409,7 @@ class TorchDataset(torch.utils.data.IterableDataset):
         num_workers: int = 1,
         shuffle: bool = False,
         buffer_size: int = 0,
+        return_index: bool = False,
     ) -> None:
         super().__init__()
 
@@ -438,6 +440,7 @@ class TorchDataset(torch.utils.data.IterableDataset):
 
         self.shuffle: bool = shuffle
         self.buffer_size: int = buffer_size * MB
+        self.return_index: bool = return_index
 
     def __iter__(self):
         worker_info = torch.utils.data.get_worker_info()
@@ -451,6 +454,7 @@ class TorchDataset(torch.utils.data.IterableDataset):
             tensors=self.tensors,
             tobytes=self.tobytes,
             use_local_cache=self.use_local_cache,
+            return_index=self.return_index,
         )
 
         if self.shuffle:
@@ -476,6 +480,7 @@ class SubIterableDataset(torch.utils.data.IterableDataset):
         num_workers: int = 1,
         buffer_size: int = 512,
         batch_size: int = 1,
+        return_index: bool = False,
     ) -> None:
         super().__init__()
 
@@ -487,6 +492,7 @@ class SubIterableDataset(torch.utils.data.IterableDataset):
             transform,
             num_workers=num_workers,
             shuffle=True,
+            return_index=return_index,
         )
 
         self.num_workers = num_workers

--- a/hub/integrations/pytorch/pytorch.py
+++ b/hub/integrations/pytorch/pytorch.py
@@ -20,7 +20,7 @@ def create_dataloader_nesteddataloader(
     collate_fn,
     pin_memory,
     drop_last,
-    return_index
+    return_index,
 ):
     import torch
     import torch.utils.data
@@ -132,7 +132,7 @@ def dataset_to_pytorch(
             collate_fn,
             pin_memory,
             drop_last,
-            return_index
+            return_index,
         )
     else:
         return torch.utils.data.DataLoader(

--- a/hub/integrations/pytorch/pytorch.py
+++ b/hub/integrations/pytorch/pytorch.py
@@ -20,6 +20,7 @@ def create_dataloader_nesteddataloader(
     collate_fn,
     pin_memory,
     drop_last,
+    return_index
 ):
     import torch
     import torch.utils.data
@@ -37,6 +38,7 @@ def create_dataloader_nesteddataloader(
             batch_size=batch_size,
             num_workers=num_workers,
             buffer_size=buffer_size,
+            return_index=return_index,
         ),
         batch_size=batch_size,
         collate_fn=collate_fn,
@@ -97,6 +99,7 @@ def dataset_to_pytorch(
     transform: Optional[Union[Dict, Callable]] = None,
     tensors: Optional[Sequence[str]] = None,
     tobytes: Union[bool, Sequence[str]] = False,
+    return_index: bool = False,
 ):
 
     import torch
@@ -129,6 +132,7 @@ def dataset_to_pytorch(
             collate_fn,
             pin_memory,
             drop_last,
+            return_index
         )
     else:
         return torch.utils.data.DataLoader(
@@ -141,6 +145,7 @@ def dataset_to_pytorch(
                 num_workers=num_workers,
                 shuffle=shuffle,
                 buffer_size=buffer_size,
+                return_index=return_index,
             ),
             batch_size=batch_size,
             collate_fn=collate_fn,


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [ ]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [ ]  I have performed a self-review of my own code and resolved any problems
- [ ]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [ ]  New and existing unit tests pass locally with my changes


### Changes

Adds return_index argument to ds.pytorch, which returns indexes. This is useful when working with shuffled data.

Usage:-
```python
ds = hub.dataset("path/to/some/dataset")
# say ds have xyz and abc as tensors

dl = ds.pytorch(shuffle=True, return_index=True, batch_size=4)

for batch in dl:
   pass

# here batch will have 3 keys, xyz, abc and index
```