### PR TITLE
[BUG] Prevent changing htype config when updating class_names

### DIFF
--- a/hub/api/tests/test_api.py
+++ b/hub/api/tests/test_api.py
@@ -1735,3 +1735,11 @@ def test_exist_ok(local_ds):
         with pytest.raises(TensorGroupAlreadyExistsError):
             ds.create_group("grp")
         ds.create_group("grp", exist_ok=True)
+
+
+def test_htype_config_bug(local_ds):
+    with local_ds as ds:
+        ds.create_tensor("abc", htype="class_label")
+        ds.abc.info.class_names.append("car")
+        ds.create_tensor("xyz", htype="class_label")
+        assert ds.xyz.info.class_names == []

--- a/hub/core/dataset/dataset.py
+++ b/hub/core/dataset/dataset.py
@@ -494,8 +494,8 @@ class Dataset:
 
         # Seperate meta and info
 
-        htype_config = HTYPE_CONFIGURATIONS.get(htype, {})
-        info_keys = htype_config.copy().pop("_info", [])
+        htype_config = HTYPE_CONFIGURATIONS.get(htype, {}).copy()
+        info_keys = htype_config.pop("_info", [])
         info_kwargs = {}
         meta_kwargs = {}
         for k, v in kwargs.items():
@@ -508,7 +508,10 @@ class Dataset:
         # Set defaults
         for k in info_keys:
             if k not in info_kwargs:
-                info_kwargs[k] = htype_config[k]
+                if k == "class_names":
+                    info_kwargs[k] = htype_config[k].copy()
+                else:
+                    info_kwargs[k] = htype_config[k]
 
         create_tensor(
             key,


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [ ]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [ ]  I have performed a self-review of my own code and resolved any problems
- [ ]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [ ]  New and existing unit tests pass locally with my changes


### Changes
Prevent updating `tensor.info.class_names` from changing `HTYPE_CONFIGURATIONS`
<!-- Describe your changes! Describe the scope of this PR's responsibilities. -->