### PR TITLE
[BUG] Fix tobytes for linked tensors

### DIFF
--- a/hub/api/tests/test_api.py
+++ b/hub/api/tests/test_api.py
@@ -1184,6 +1184,14 @@ def test_tobytes(memory_ds, compressed_image_paths, audio_paths):
         assert ds.audio[i].tobytes() == audio_bytes
 
 
+def test_tobytes_link(memory_ds):
+    with memory_ds as ds:
+        ds.create_tensor("images", htype="link[image]")
+        ds.images.append(hub.link("https://picsum.photos/id/237/200/300"))
+        sample = hub.read("https://picsum.photos/id/237/200/300")
+        assert ds.images[0].tobytes() == sample.buffer
+
+
 def test_tensor_clear(local_ds_generator):
     ds = local_ds_generator()
     a = ds.create_tensor("a")

--- a/hub/core/sample.py
+++ b/hub/core/sample.py
@@ -125,6 +125,8 @@ class Sample:
 
     @property
     def buffer(self):
+        if self._buffer is None and self.path is not None:
+            self._read_from_path()
         if self._buffer is not None:
             return self._buffer
         return self.compressed_bytes(self.compression)

--- a/hub/core/tensor.py
+++ b/hub/core/tensor.py
@@ -799,7 +799,7 @@ class Tensor:
         self.check_link_ready()
         idx = self.index.values[0].value
         if self.is_link:
-            return self.chunk_engine.get_hub_read_sample(idx).compressed_bytes  # type: ignore
+            return self.chunk_engine.get_hub_read_sample(idx).buffer  # type: ignore
         return self.chunk_engine.read_bytes_for_sample(idx)  # type: ignore
 
     def _pop(self):


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [ ]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [ ]  I have performed a self-review of my own code and resolved any problems
- [ ]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [ ]  New and existing unit tests pass locally with my changes


### Changes
Fixed `tensor.tobytes` for linked tensors
<!-- Describe your changes! Describe the scope of this PR's responsibilities. -->