### PR TITLE
Correctly passing credentials to gcp provider

### DIFF
--- a/hub/core/sample.py
+++ b/hub/core/sample.py
@@ -394,7 +394,7 @@ class Sample:
             return self.storage.get_object_from_full_url(self.path)
         path = self.path.replace("gcp://", "").replace("gcs://", "")  # type: ignore
         root, key = self._get_root_and_key(path)
-        gcs = GCSProvider(root, **self._creds)
+        gcs = GCSProvider(root, token=self._creds)
         return gcs[key]
 
     def _read_from_gdrive(self) -> bytes:


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [ ]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [ ]  I have performed a self-review of my own code and resolved any problems
- [ ]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [ ]  New and existing unit tests pass locally with my changes


### Changes

Just changed the way of passing credentials to the `GCSProvider`, to be like it is done in the `storage_provider_from_path` method.

<!-- Describe your changes! Describe the scope of this PR's responsibilities. -->