### PR TITLE
[AL-1795] Changes .data to return both numeric and text value for class labels

### DIFF
--- a/hub/api/tests/test_api.py
+++ b/hub/api/tests/test_api.py
@@ -1737,7 +1737,7 @@ def test_exist_ok(local_ds):
         ds.create_group("grp", exist_ok=True)
 
 
-def test_text_label(local_ds_generator):
+def verify_label_data(ds):
     text_labels = [
         ["airplane"],
         ["boat"],
@@ -1747,26 +1747,43 @@ def test_text_label(local_ds_generator):
         ["airplane"],
         ["car"],
     ]
+    arr = np.array([0, 1, 0, 2, 0, 0, 2]).reshape((7, 1))
+
+    # abc
+    assert ds.abc.info.class_names == ["airplane", "boat", "car"]
+    np_data = ds.abc.numpy()
+    data = ds.abc.data()
+    assert set(data.keys()) == {"numeric", "text"}
+    np.testing.assert_array_equal(np_data, arr)
+    np.testing.assert_array_equal(data["numeric"], np_data)
+    assert data["text"] == text_labels
+
+    # xyz
+    assert ds.xyz.info.class_names == []
+    np_data = ds.xyz.numpy()
+    data = ds.xyz.data()
+    assert set(data.keys()) == {"numeric"}
+    np.testing.assert_array_equal(np_data, arr)
+    np.testing.assert_array_equal(data["numeric"], np_data)
+
+
+def test_text_label(local_ds_generator):
     with local_ds_generator() as ds:
         ds.create_tensor("abc", htype="class_label")
         ds.abc.append("airplane")
         ds.abc.append("boat")
         ds.abc.append("airplane")
         ds.abc.extend(["car", "airplane", 0, 2])
-        assert ds.abc.info.class_names == ["airplane", "boat", "car"]
-        np_data = ds.abc.numpy()
-        data = ds.abc.data()
-        np.testing.assert_array_equal(
-            np_data, np.array([0, 1, 0, 2, 0, 0, 2]).reshape((7, 1))
-        )
-        np.testing.assert_array_equal(data["numeric"], np_data)
-        assert data["text"] == text_labels
+
+        ds.create_tensor("xyz", htype="class_label")
+        ds.xyz.append(0)
+        ds.xyz.append(1)
+        ds.xyz.append(0)
+        ds.xyz.extend([2, 0, 0, 2])
+        verify_label_data(ds)
 
     ds = local_ds_generator()
-    assert ds.abc.info.class_names == ["airplane", "boat", "car"]
-
-    data = ds.abc.data()
-    assert data["text"] == text_labels
+    verify_label_data(ds)
 
 
 def test_empty_sample_partial_read(s3_ds):

--- a/hub/api/tests/test_api.py
+++ b/hub/api/tests/test_api.py
@@ -1738,19 +1738,35 @@ def test_exist_ok(local_ds):
 
 
 def test_text_label(local_ds_generator):
+    text_labels = [
+        ["airplane"],
+        ["boat"],
+        ["airplane"],
+        ["car"],
+        ["airplane"],
+        ["airplane"],
+        ["car"],
+    ]
     with local_ds_generator() as ds:
         ds.create_tensor("abc", htype="class_label")
         ds.abc.append("airplane")
         ds.abc.append("boat")
         ds.abc.append("airplane")
         ds.abc.extend(["car", "airplane", 0, 2])
-        ds.abc.info.class_names == ["airplane", "boat", "car"]
+        assert ds.abc.info.class_names == ["airplane", "boat", "car"]
+        np_data = ds.abc.numpy()
+        data = ds.abc.data()
         np.testing.assert_array_equal(
-            ds.abc.numpy(), np.array([0, 1, 0, 2, 0, 0, 2]).reshape((7, 1))
+            np_data, np.array([0, 1, 0, 2, 0, 0, 2]).reshape((7, 1))
         )
+        np.testing.assert_array_equal(data["numeric"], np_data)
+        assert data["text"] == text_labels
 
     ds = local_ds_generator()
     assert ds.abc.info.class_names == ["airplane", "boat", "car"]
+
+    data = ds.abc.data()
+    assert data["text"] == text_labels
 
 
 def test_empty_sample_partial_read(s3_ds):

--- a/hub/core/tensor.py
+++ b/hub/core/tensor.py
@@ -36,6 +36,7 @@ from hub.util.keys import (
     get_sample_shape_tensor_key,
 )
 from hub.util.modified import get_modified_indexes
+from hub.util.numeric_to_text import numeric_to_text
 from hub.util.shape_interval import ShapeInterval
 from hub.util.exceptions import (
     TensorDoesNotExistError,
@@ -776,6 +777,13 @@ class Tensor:
                 data["timestamps"] = self.timestamp
             if aslist:
                 data["timestamps"] = data["timestamps"].tolist()  # type: ignore
+            return data
+        elif htype == "class_label":
+            labels = self.numpy(aslist=aslist)
+            data = {
+                "numeric": labels,
+                "text": numeric_to_text(labels, self.info.class_names),
+            }
             return data
         else:
             return self.numpy(aslist=aslist)

--- a/hub/core/tensor.py
+++ b/hub/core/tensor.py
@@ -780,10 +780,10 @@ class Tensor:
             return data
         elif htype == "class_label":
             labels = self.numpy(aslist=aslist)
-            data = {
-                "numeric": labels,
-                "text": numeric_to_text(labels, self.info.class_names),
-            }
+            data = {"numeric": labels}
+            class_names = self.info.class_names
+            if class_names:
+                data["text"] = numeric_to_text(labels, self.info.class_names)
             return data
         else:
             return self.numpy(aslist=aslist)

--- a/hub/util/numeric_to_text.py
+++ b/hub/util/numeric_to_text.py
@@ -1,0 +1,10 @@
+import numpy as np
+
+
+def numeric_to_text(inp, class_names: list[str]):
+    if isinstance(inp, np.integer):
+        idx = int(inp)
+        if idx < len(class_names):
+            return class_names[idx]
+        return None
+    return [numeric_to_text(item, class_names) for item in inp]

--- a/hub/util/numeric_to_text.py
+++ b/hub/util/numeric_to_text.py
@@ -1,6 +1,7 @@
 import numpy as np
 from typing import List
 
+
 def numeric_to_text(inp, class_names: List[str]):
     if isinstance(inp, np.integer):
         idx = int(inp)

--- a/hub/util/numeric_to_text.py
+++ b/hub/util/numeric_to_text.py
@@ -1,7 +1,7 @@
 import numpy as np
+from typing import List
 
-
-def numeric_to_text(inp, class_names: list[str]):
+def numeric_to_text(inp, class_names: List[str]):
     if isinstance(inp, np.integer):
         idx = int(inp)
         if idx < len(class_names):


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [ ]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [ ]  I have performed a self-review of my own code and resolved any problems
- [ ]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [ ]  New and existing unit tests pass locally with my changes


### Changes
tensor.data() for htype class labels returns a dictionary containing 2 keys, "numeric" which has the same value as .numpy() and text which is converted into text class labels if class labels are present, otherwise key is skipped.
