### PR TITLE
[BUG] Fix setitem issue with list of length 1

### DIFF
--- a/hub/api/tests/test_api.py
+++ b/hub/api/tests/test_api.py
@@ -1767,3 +1767,14 @@ def test_htype_config_bug(local_ds):
         ds.abc.info.class_names.append("car")
         ds.create_tensor("xyz", htype="class_label")
         assert ds.xyz.info.class_names == []
+
+def test_update_bug(local_ds):
+    with local_ds as ds:
+        bb = ds.create_tensor("bb", "bbox", dtype="float64")
+        arr1 = np.array([[1.0, 2.0, 3.0, 4.0]])
+        bb.append(arr1)
+        np.testing.assert_array_equal(bb[0].numpy(), arr1)
+
+        arr2 = np.array([[5.0, 6.0, 7.0, 8.0]])
+        bb[0] = arr2
+        np.testing.assert_array_equal(bb[0].numpy(), arr2)

--- a/hub/api/tests/test_api.py
+++ b/hub/api/tests/test_api.py
@@ -1768,6 +1768,7 @@ def test_htype_config_bug(local_ds):
         ds.create_tensor("xyz", htype="class_label")
         assert ds.xyz.info.class_names == []
 
+
 def test_update_bug(local_ds):
     with local_ds as ds:
         bb = ds.create_tensor("bb", "bbox", dtype="float64")

--- a/hub/api/tests/test_update_samples.py
+++ b/hub/api/tests/test_update_samples.py
@@ -102,8 +102,8 @@ def test(local_ds_generator, compression):
 
     # update single sample
     _make_update_assert_equal(
-        gen, "images", -1, np.ones((1, 28, 28), dtype="uint8") * 75
-    )  # same shape (with 1)
+        gen, "images", -1, np.ones((28, 28), dtype="uint8") * 75
+    )  # same shape
     _make_update_assert_equal(
         gen, "images", -1, np.ones((28, 28), dtype="uint8") * 75
     )  # same shape
@@ -111,8 +111,8 @@ def test(local_ds_generator, compression):
         gen, "images", 0, np.ones((28, 25), dtype="uint8") * 5
     )  # new shape
     _make_update_assert_equal(
-        gen, "images", 0, np.ones((1, 32, 32), dtype="uint8") * 5
-    )  # new shape (with 1)
+        gen, "images", 0, np.ones((32, 32), dtype="uint8") * 5
+    )  # new shape
     _make_update_assert_equal(
         gen, "images", -1, np.ones((0, 0), dtype="uint8")
     )  # empty sample (new shape)
@@ -164,7 +164,7 @@ def test_hub_read(local_ds_generator, images_compression, cat_path, flower_path)
     ds.images[0] = hub.read(cat_path)
     np.testing.assert_array_equal(ds.images[0].numpy(), hub.read(cat_path).array)
 
-    ds.images[1] = [hub.read(flower_path)]
+    ds.images[1] = hub.read(flower_path)
     np.testing.assert_array_equal(ds.images[1].numpy(), hub.read(flower_path).array)
 
     ds.images[8:10] = [hub.read(cat_path), hub.read(flower_path)]

--- a/hub/core/tensor.py
+++ b/hub/core/tensor.py
@@ -629,6 +629,7 @@ class Tensor:
             )
             return
 
+        # we're modifying a single sample, convert it to a list as chunk engine expects multiple samples
         if not item_index.values[0].subscriptable():
             value = [value]
 

--- a/hub/core/tensor.py
+++ b/hub/core/tensor.py
@@ -629,7 +629,7 @@ class Tensor:
             )
             return
 
-        if isinstance(item, int):
+        if not item_index.values[0].subscriptable():
             value = [value]
 
         self.chunk_engine.update(

--- a/hub/core/tensor.py
+++ b/hub/core/tensor.py
@@ -629,7 +629,7 @@ class Tensor:
             )
             return
 
-        if not item_index.values[0].subscriptable():
+        if not item_index.values[0].subscriptable() and not self.is_sequence:
             # we're modifying a single sample, convert it to a list as chunk engine expects multiple samples
             value = [value]
 

--- a/hub/core/tensor.py
+++ b/hub/core/tensor.py
@@ -629,6 +629,9 @@ class Tensor:
             )
             return
 
+        if isinstance(item, int):
+            value = [value]
+
         self.chunk_engine.update(
             self.index[item_index],
             value,

--- a/hub/core/tensor.py
+++ b/hub/core/tensor.py
@@ -629,8 +629,8 @@ class Tensor:
             )
             return
 
-        # we're modifying a single sample, convert it to a list as chunk engine expects multiple samples
         if not item_index.values[0].subscriptable():
+            # we're modifying a single sample, convert it to a list as chunk engine expects multiple samples
             value = [value]
 
         self.chunk_engine.update(


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [ ]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [ ]  I have performed a self-review of my own code and resolved any problems
- [ ]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [ ]  New and existing unit tests pass locally with my changes


### Changes

When the value in setitem is a single sample, in some cases it was being treated as a list of samples, leading to loss of dimensionality when appending, which caused errors