### PR TITLE
[AL-1806] Do partial reads to retrieve shape for samples

### DIFF
--- a/hub/core/chunk_engine.py
+++ b/hub/core/chunk_engine.py
@@ -1248,20 +1248,22 @@ class ChunkEngine:
         global_sample_index: int,
     ) -> Tuple[int, ...]:
         enc = self.chunk_id_encoder
-        if self.compression in VIDEO_COMPRESSIONS or self.tensor_meta.htype == "video":
-            chunks = [
-                self.get_video_chunk(idx)[0]
-                for idx in self.chunk_id_encoder[global_sample_index]
-            ]
+        if self._is_tiled_sample(global_sample_index):
+            return self.tile_encoder.get_sample_shape(global_sample_index)
+        if self.is_video:
+            chunk_id = enc[global_sample_index][0]
+            chunk = self.get_video_chunk(chunk_id)[0]
         else:
-            chunks = self.get_chunks_for_sample(global_sample_index)
-        if len(chunks) == 1:
+            chunk_id, row, worst_case_header_size = self.get_chunk_info(
+                global_sample_index, fetch_chunks=False
+            )
             local_sample_index = enc.translate_index_relative_to_chunks(
                 global_sample_index
             )
-            return tuple(map(int, chunks[0].shapes_encoder[local_sample_index]))
-        else:
-            return self.tile_encoder.get_sample_shape(global_sample_index)
+            chunk = self.get_chunk_from_chunk_id(
+                chunk_id, partial_chunk_bytes=worst_case_header_size
+            )
+        return tuple(map(int, chunk.shapes_encoder[local_sample_index]))
 
     def read_sample_from_chunk(
         self,
@@ -1321,10 +1323,12 @@ class ChunkEngine:
             return sample[tuple(entry.value for entry in index.values[2:])]
         return sample
 
-    def get_basic_sample(self, global_sample_index, index, fetch_chunks=False):
+    def get_chunk_info(self, global_sample_index, fetch_chunks):
+        """Returns the chunk_id, row and worst case header size of chunk containing the given sample."""
         enc = self.chunk_id_encoder
         out = enc.__getitem__(global_sample_index, return_row_index=True)
         chunk_id, row = out[0][0], out[0][1]
+
         worst_case_header_size = 0
         num_samples_in_chunk = -1
         if (
@@ -1354,6 +1358,13 @@ class ChunkEngine:
             worst_case_header_size += shape_enc_size
             worst_case_header_size += bytes_enc_size
 
+        return chunk_id, row, worst_case_header_size
+
+    def get_basic_sample(self, global_sample_index, index, fetch_chunks=False):
+        enc = self.chunk_id_encoder
+        chunk_id, row, worst_case_header_size = self.get_chunk_info(
+            global_sample_index, fetch_chunks
+        )
         local_sample_index = enc.translate_index_relative_to_chunks(global_sample_index)
         chunk = self.get_chunk_from_chunk_id(
             chunk_id, partial_chunk_bytes=worst_case_header_size
@@ -1363,7 +1374,7 @@ class ChunkEngine:
         )[tuple(entry.value for entry in index.values[1:])]
 
     def get_non_tiled_sample(self, global_sample_index, index, fetch_chunks=False):
-        if self.compression in VIDEO_COMPRESSIONS or self.tensor_meta.htype == "video":
+        if self.is_video:
             return self.get_video_sample(global_sample_index, index)
         return self.get_basic_sample(
             global_sample_index, index, fetch_chunks=fetch_chunks
@@ -1615,6 +1626,12 @@ class ChunkEngine:
     @property
     def is_sequence(self):
         return self.tensor_meta.is_sequence
+
+    @property
+    def is_video(self):
+        return (
+            self.compression in VIDEO_COMPRESSIONS or self.tensor_meta.htype == "video"
+        )
 
     @property
     def sequence_encoder_exists(self) -> bool:

--- a/hub/core/chunk_engine.py
+++ b/hub/core/chunk_engine.py
@@ -1250,15 +1250,13 @@ class ChunkEngine:
         enc = self.chunk_id_encoder
         if self._is_tiled_sample(global_sample_index):
             return self.tile_encoder.get_sample_shape(global_sample_index)
+        local_sample_index = enc.translate_index_relative_to_chunks(global_sample_index)
         if self.is_video:
             chunk_id = enc[global_sample_index][0]
             chunk = self.get_video_chunk(chunk_id)[0]
         else:
-            chunk_id, row, worst_case_header_size = self.get_chunk_info(
+            chunk_id, _, worst_case_header_size = self.get_chunk_info(
                 global_sample_index, fetch_chunks=False
-            )
-            local_sample_index = enc.translate_index_relative_to_chunks(
-                global_sample_index
             )
             chunk = self.get_chunk_from_chunk_id(
                 chunk_id, partial_chunk_bytes=worst_case_header_size


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [x]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [x]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [x]  I have performed a self-review of my own code and resolved any problems
- [x]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [x]  I have described and made corresponding changes to the relevant documentation
- [ ]  New and existing unit tests pass locally with my changes


### Changes

Does partial reads to only get header while reading shapes instead of getting full chunks to speed up shape retrieval in cases where a shape encoder doesn't exist.