### PR TITLE
Fix linked video playback test

### DIFF
--- a/hub/visualizer/tests/test_playback.py
+++ b/hub/visualizer/tests/test_playback.py
@@ -27,6 +27,9 @@ def test_video_playback(local_ds_generator, video_paths):
     assert byte_stream == expected
 
 
+@pytest.mark.skipif(
+    os.name == "nt" and sys.version_info < (3, 7), reason="requires python 3.7 or above"
+)
 def test_linked_video_playback(local_ds_generator):
     with local_ds_generator() as ds:
         ds.create_tensor("video_links", htype="link[video]")


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [ ]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [ ]  I have performed a self-review of my own code and resolved any problems
- [ ]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [ ]  New and existing unit tests pass locally with my changes


### Changes
Skip video playback test for windows python 3.6
<!-- Describe your changes! Describe the scope of this PR's responsibilities. -->