### PR TITLE
[Optimization] Make sample size calculation faster in pytorch

### DIFF
--- a/hub/integrations/pytorch/shuffle_buffer.py
+++ b/hub/integrations/pytorch/shuffle_buffer.py
@@ -83,7 +83,7 @@ class ShuffleBuffer:
         elif isinstance(sample, Sequence):
             return sum(self._sample_size(tensor) for tensor in sample)
         elif isinstance(sample, torch.Tensor):
-            return sample.storage().element_size() * reduce(mul, sample.shape, 1)
+            return sample.element_size() * reduce(mul, sample.shape, 1)
         elif isinstance(sample, np.ndarray):
             return sample.nbytes
         raise ValueError(


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [ ]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [ ]  I have performed a self-review of my own code and resolved any problems
- [ ]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [ ]  New and existing unit tests pass locally with my changes


### Changes

Directly access tensor.element_size() instead of using tensor.storage.element_size() which is slower