### PR TITLE
[AL-1820] view.sample_indices

### DIFF
--- a/hub/core/dataset/dataset.py
+++ b/hub/core/dataset/dataset.py
@@ -2685,6 +2685,10 @@ class Dataset:
         vds.delete(large_ok=True)
         return info
 
+    @property
+    def sample_indices(self):
+        return self.index.values[0].indices(len(self))
+
 
 def _copy_tensor(sample_in, sample_out, tensor_name):
     sample_out[tensor_name].append(sample_in[tensor_name])

--- a/hub/core/dataset/dataset.py
+++ b/hub/core/dataset/dataset.py
@@ -2687,7 +2687,9 @@ class Dataset:
 
     @property
     def sample_indices(self):
-        return self.index.values[0].indices(len(self))
+        return self.index.values[0].indices(
+            min(t.num_samples for t in self.tensors.values())
+        )
 
 
 def _copy_tensor(sample_in, sample_out, tensor_name):

--- a/hub/core/query/test/test_query.py
+++ b/hub/core/query/test/test_query.py
@@ -316,3 +316,12 @@ def test_query_bug_transformed_dataset(local_ds):
 
     ds_view = local_ds.filter("classes == 'class_0'", scheduler="threaded")
     np.testing.assert_array_equal(ds_view.classes.numpy()[:, 0], [0] * len(ds_view))
+
+
+def test_view_sample_indices(memory_ds):
+    ds = memory_ds
+    with ds:
+        ds.create_tensor("x")
+        ds.x.extend(list(range(10)))
+    assert list(ds[:5].sample_indices) == list(range(5))
+    assert list(ds.x[:5].sample_indices) == list(range(5))

--- a/hub/core/query/test/test_query.py
+++ b/hub/core/query/test/test_query.py
@@ -323,3 +323,4 @@ def test_view_sample_indices(memory_ds):
         ds.create_tensor("x")
         ds.x.extend(list(range(10)))
     assert list(ds[:5].sample_indices) == list(range(5))
+    assert list(ds[5:].sample_indices) == list(range(5, 10))

--- a/hub/core/query/test/test_query.py
+++ b/hub/core/query/test/test_query.py
@@ -6,7 +6,6 @@ from hub.core.query import DatasetQuery
 from hub.util.exceptions import DatasetViewSavingError
 import hub
 from uuid import uuid4
-import itertools
 
 
 first_row = {"images": [1, 2, 3], "labels": [0]}

--- a/hub/core/query/test/test_query.py
+++ b/hub/core/query/test/test_query.py
@@ -1,5 +1,4 @@
 import pytest
-from hub.core import query
 
 import numpy as np
 
@@ -7,7 +6,7 @@ from hub.core.query import DatasetQuery
 from hub.util.exceptions import DatasetViewSavingError
 import hub
 from uuid import uuid4
-import os
+import itertools
 
 
 first_row = {"images": [1, 2, 3], "labels": [0]}
@@ -324,4 +323,3 @@ def test_view_sample_indices(memory_ds):
         ds.create_tensor("x")
         ds.x.extend(list(range(10)))
     assert list(ds[:5].sample_indices) == list(range(5))
-    assert list(ds.x[:5].sample_indices) == list(range(5))

--- a/hub/core/query/test/test_query.py
+++ b/hub/core/query/test/test_query.py
@@ -323,3 +323,14 @@ def test_view_sample_indices(memory_ds):
         ds.x.extend(list(range(10)))
     assert list(ds[:5].sample_indices) == list(range(5))
     assert list(ds[5:].sample_indices) == list(range(5, 10))
+
+
+def test_query_view_union(local_ds):
+    ds = local_ds
+    with ds:
+        ds.create_tensor("x")
+        ds.x.extend(list(range(10)))
+    v1 = ds.filter(lambda s: s.x.numpy() % 2)
+    v2 = ds.filter(lambda s: not (s.x.numpy() % 2))
+    union = ds[sorted(list(set(v1.sample_indices).union(v2.sample_indices)))]
+    np.testing.assert_array_equal(union.x.numpy(), ds.x.numpy())

--- a/hub/core/tensor.py
+++ b/hub/core/tensor.py
@@ -1011,3 +1011,7 @@ class Tensor:
             "is_link": tensor_meta.is_link,
             "is_sequence": tensor_meta.is_sequence,
         }
+
+    @property
+    def sample_indices(self):
+        return self.index.values[0].indices(len(self))

--- a/hub/core/tensor.py
+++ b/hub/core/tensor.py
@@ -1014,4 +1014,4 @@ class Tensor:
 
     @property
     def sample_indices(self):
-        return self.index.values[0].indices(len(self))
+        return self.index.values[0].indices(self.num_samples)


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [ ]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [ ]  I have performed a self-review of my own code and resolved any problems
- [ ]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [ ]  New and existing unit tests pass locally with my changes


### Changes

`list(view.sample_indices)` returns the indices of samples in a view.

Can create view unions like this:

```
view1 = ds[:10]
view2 = ds[5:15]
union = ds[sorted(list(set(view1.sample_indices).union(view2.sample_indices)))]

```

<!-- Describe your changes! Describe the scope of this PR's responsibilities. -->