### PR TITLE
Changed dev location to https://app-dev.activeloop.dev/

### DIFF
--- a/hub/client/config.py
+++ b/hub/client/config.py
@@ -7,7 +7,7 @@ ALL_AGREEMENTS_PATH = os.path.expanduser("~/.activeloop/agreements")
 
 HUB_REST_ENDPOINT = "https://app.activeloop.ai"
 HUB_REST_ENDPOINT_STAGING = "https://app-staging.activeloop.dev"
-HUB_REST_ENDPOINT_DEV = "https://app.dev.activeloop.ai"
+HUB_REST_ENDPOINT_DEV = "https://app-dev.activeloop.dev"
 HUB_REST_ENDPOINT_LOCAL = "http://localhost:7777"
 USE_LOCAL_HOST = False
 USE_DEV_ENVIRONMENT = False


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [X ]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [X ]  I have commented my code, particularly in hard-to-understand areas
- [X ]  I have kept the `coverage-rate` up
- [X ]  I have performed a self-review of my own code and resolved any problems
- [ ]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the saXme change
- [X ]  I have described and made corresponding changes to the relevant documentation
- [ X]  New and existing unit tests pass locally with my changes


### Changes

As we have updated the location of dev to https://app-dev.activeloop.dev, we need to update this in the hub client configuration.  We are setting  HUB_REST_ENDPOINT_DEV = "https://app-dev.activeloop.dev".
