### PR TITLE
Adds ability to pop sample from dataset instead of popping from individual tensors

### DIFF
--- a/hub/api/tests/test_pop.py
+++ b/hub/api/tests/test_pop.py
@@ -183,3 +183,26 @@ def test_diff_pop(local_ds_generator):
             }
         }
         assert diff2 == {}
+
+
+def test_ds_pop(local_ds):
+    with local_ds as ds:
+        ds.create_tensor("images")
+        ds.create_tensor("labels")
+
+        for i in range(100):
+            ds.images.append(i * np.ones((i + 1, i + 1, 3)))
+            if i < 50:
+                ds.labels.append(i)
+
+        ds.pop(80)  # doesn't pop from tensors shorter than length 80
+        assert len(ds.images) == 99
+        assert len(ds.labels) == 50
+
+        ds.pop(20)
+        assert len(ds.images) == 98
+        assert len(ds.labels) == 49
+
+        ds.pop()  # only pops from the longest tensor
+        assert len(ds.images) == 97
+        assert len(ds.labels) == 49

--- a/hub/api/tests/test_pop.py
+++ b/hub/api/tests/test_pop.py
@@ -1,6 +1,7 @@
 import numpy as np
 import hub
 from hub.api.tests.test_api_tiling import compressions_paremetrized
+import pytest
 
 
 def pop_helper_basic(ds, pop_count):
@@ -189,6 +190,7 @@ def test_ds_pop(local_ds):
     with local_ds as ds:
         ds.create_tensor("images")
         ds.create_tensor("labels")
+        ds.pop()
 
         for i in range(100):
             ds.images.append(i * np.ones((i + 1, i + 1, 3)))
@@ -206,3 +208,6 @@ def test_ds_pop(local_ds):
         ds.pop()  # only pops from the longest tensor
         assert len(ds.images) == 97
         assert len(ds.labels) == 49
+
+        with pytest.raises(IndexError):
+            ds.pop(-5)

--- a/hub/api/tests/test_pop.py
+++ b/hub/api/tests/test_pop.py
@@ -190,7 +190,9 @@ def test_ds_pop(local_ds):
     with local_ds as ds:
         ds.create_tensor("images")
         ds.create_tensor("labels")
-        ds.pop()
+
+        with pytest.raises(IndexError):
+            ds.pop()
 
         for i in range(100):
             ds.images.append(i * np.ones((i + 1, i + 1, 3)))

--- a/hub/core/dataset/dataset.py
+++ b/hub/core/dataset/dataset.py
@@ -3116,14 +3116,16 @@ class Dataset:
         Raises:
             IndexError: If the index is out of range.
         """
+        max_len = max((t.num_samples for t in self.tensors.values()), default=0)
+        if max_len == 0:
+            raise IndexError("Can't pop from empty dataset.")
+
         if index is None:
-            index = -1
-            for tensor in self.tensors.values():
-                index = max(index, tensor.num_samples - 1)
-            if index == -1:
-                return
-        elif index < 0:
-            raise IndexError("Pop only supports indexes >= 0")
+            index = max_len - 1
+        if index < 0 or index >= max_len:
+            raise IndexError(
+                f"Index {index} is out of range. The longest tensor has {max_len} samples."
+            )
 
         for tensor in self.tensors.values():
             if tensor.num_samples > index:

--- a/hub/core/dataset/dataset.py
+++ b/hub/core/dataset/dataset.py
@@ -3111,7 +3111,7 @@ class Dataset:
         For any tensor if the index >= len(tensor), the sample won't be popped from it.
 
         Args:
-            index (int, optional): The index of the sample to be removed. If it is None, the index becomes the length of the longest tensor - 1.
+            index (int, Optional): The index of the sample to be removed. If it is None, the index becomes the length of the longest tensor - 1.
 
         Raises:
             IndexError: If the index is out of range.

--- a/hub/core/dataset/dataset.py
+++ b/hub/core/dataset/dataset.py
@@ -3122,7 +3122,10 @@ class Dataset:
 
         if index is None:
             index = max_len - 1
-        if index < 0 or index >= max_len:
+
+        if index < 0:
+            raise IndexError("Pop doesn't support negative indices.")
+        elif index >= max_len:
             raise IndexError(
                 f"Index {index} is out of range. The longest tensor has {max_len} samples."
             )

--- a/hub/core/dataset/dataset.py
+++ b/hub/core/dataset/dataset.py
@@ -1961,6 +1961,7 @@ class Dataset:
         for i in range(n):
             self.append({k: v[i] for k, v in samples.items()})
 
+    @invalid_view_op
     def append(self, sample: Dict[str, Any], skip_ok: bool = False):
         """Append samples to mutliple tensors at once. This method expects all tensors being updated to be of the same length.
         Args:
@@ -3048,6 +3049,17 @@ class Dataset:
 
     def _disable_padding(self):
         self._pad_tensors = False
+
+    @invalid_view_op
+    def pop(self, index: Optional[int] = None):
+        if index is None:
+            index = 0
+            for tensor in self.tensors.values():
+                index = max(index, tensor.num_samples)
+
+        for tensor in self.tensors.values():
+            if tensor.num_samples > index:
+                tensor.pop(index)
 
 
 def _copy_tensor(sample_in, sample_out, tensor_name):

--- a/hub/core/dataset/dataset.py
+++ b/hub/core/dataset/dataset.py
@@ -3052,10 +3052,20 @@ class Dataset:
 
     @invalid_view_op
     def pop(self, index: Optional[int] = None):
+        """
+        Removes a sample from all the tensors of the dataset.
+        For any tensor if the index >= len(tensor), the sample won't be popped from it.
+
+        Args:
+            index (int, optional): The index of the sample to be removed. If it is None, the index becomes the length of the longest tensor - 1.
+
+        Raises:
+            IndexError: If the index is out of range.
+        """
         if index is None:
             index = -1
             for tensor in self.tensors.values():
-                index = max(index, tensor.num_samples) - 1
+                index = max(index, tensor.num_samples - 1)
             if index == -1:
                 return
         elif index < 0:

--- a/hub/core/dataset/dataset.py
+++ b/hub/core/dataset/dataset.py
@@ -3053,9 +3053,13 @@ class Dataset:
     @invalid_view_op
     def pop(self, index: Optional[int] = None):
         if index is None:
-            index = 0
+            index = -1
             for tensor in self.tensors.values():
-                index = max(index, tensor.num_samples)
+                index = max(index, tensor.num_samples) - 1
+            if index == -1:
+                return
+        elif index < 0:
+            raise IndexError("Pop only supports indexes >= 0")
 
         for tensor in self.tensors.values():
             if tensor.num_samples > index:


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [x]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [x]  I have commented my code, particularly in hard-to-understand areas
- [x]  I have kept the `coverage-rate` up
- [x]  I have performed a self-review of my own code and resolved any problems
- [x]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [x]  I have described and made corresponding changes to the relevant documentation
- [x]  New and existing unit tests pass locally with my changes


### Changes
Adds ds.pop method to Dataset to pop from multiple tensors at once instead of popping from each tensor one by one
