### PR TITLE
Fix double indexing when saving strided views

### DIFF
--- a/hub/core/dataset/dataset.py
+++ b/hub/core/dataset/dataset.py
@@ -2173,7 +2173,7 @@ class Dataset:
                         create_shape_tensor=False,
                         create_id_tensor=False,
                         create_sample_info_tensor=False,
-                    ).extend(list(self.index.values[0].indices(len(self))))
+                    ).extend(list(self.index.values[0].indices(self.num_samples)))
                     info["first-index-subscriptable"] = self.index.subscriptable_at(0)
                     if len(self.index) > 1:
                         info["sub-sample-index"] = Index(

--- a/hub/core/query/test/test_query.py
+++ b/hub/core/query/test/test_query.py
@@ -386,7 +386,7 @@ def test_query_view_union(local_ds):
 def test_view_saving_with_path(local_ds):
     with local_ds as ds:
         ds.create_tensor("nums")
-        ds.nums.extend([i for i in range(100)])
+        ds.nums.extend(list(range(100)))
         ds.commit()
         with pytest.raises(DatasetViewSavingError):
             ds[:10].save_view(path=local_ds.path)
@@ -396,3 +396,14 @@ def test_view_saving_with_path(local_ds):
         with pytest.raises(DatasetViewSavingError):
             ds[:10].save_view(path=vds_path)
         hub.delete(vds_path, force=True)
+
+
+def test_strided_view_bug(local_ds):
+    with local_ds as ds:
+        ds.create_tensor("nums")
+        ds.nums.extend(list(range(200)))
+        ds.commit()
+    view = ds[:100:2]
+    view.save_view()
+    view2 = ds.get_views()[0].load()
+    np.testing.assert_array_equal(view.nums.numpy(), view2.nums.numpy())

--- a/hub/core/query/test/test_query.py
+++ b/hub/core/query/test/test_query.py
@@ -136,8 +136,8 @@ def test_sub_sample_view_save(optimize, idx_subscriptable, compressed_image_path
     _populate_data(ds, linked=True, n=100, paths=compressed_image_paths, labels=False)
     with pytest.raises(DatasetViewSavingError):
         ds.save_view(optimize=optimize)
-    view = ds[10:77, 2:17, 19:31, :1]
-    arr = arr[10:77, 2:17, 19:31, :1]
+    view = ds[10:77:2, 2:17, 19:31, :1]
+    arr = arr[10:77:2, 2:17, 19:31, :1]
     if not idx_subscriptable:
         view = view[0]
         arr = arr[0]


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [ ]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [ ]  I have performed a self-review of my own code and resolved any problems
- [ ]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [ ]  New and existing unit tests pass locally with my changes


### Changes

<!-- Describe your changes! Describe the scope of this PR's responsibilities. -->