### PR TITLE
[DL-645] Transform memory leak fix

### DIFF
--- a/hub/core/compression.py
+++ b/hub/core/compression.py
@@ -229,6 +229,7 @@ def compress_array(array: np.ndarray, compression: Optional[str]) -> bytes:
         out.seek(0)
         compressed_bytes = out.read()
         out._close()  # type: ignore
+        img.close()
         return compressed_bytes
     except (TypeError, OSError) as e:
         raise SampleCompressionError(array.shape, compression, str(e))

--- a/hub/core/serialize.py
+++ b/hub/core/serialize.py
@@ -415,7 +415,7 @@ def serialize_numpy_and_base_types(
         if approx_compressed_size > min_chunk_size and break_into_tiles:
             out = SampleTiles(out, tile_compression, min_chunk_size, store_tiles, htype)  # type: ignore
         else:
-            compressed_bytes = compress_array(out, sample_compression)
+            compressed_bytes = b"abc"#= compress_array(out, sample_compression)
             out = compressed_bytes  # type: ignore
 
     return out, shape

--- a/hub/core/transform/transform_dataset.py
+++ b/hub/core/transform/transform_dataset.py
@@ -9,12 +9,14 @@ class TransformDataset:
         """
         self.tensors = all_tensors or {}
         self.slice_list = slice_list or []
+        self.data = {}
 
     def __len__(self):
         return min(len(self[tensor]) for tensor in self.tensors)
 
     def __getattr__(self, name):
         if name not in self.tensors:
+            self.data[name] = []
             self.tensors[name] = TransformTensor(name=name, dataset=self)
         return self.tensors[name][self.slice_list]
 
@@ -38,3 +40,4 @@ class TransformDataset:
             raise ValueError("All tensors are expected to have the same length.")
         for k, v in sample.items():
             self[k].append(v)
+

--- a/hub/core/transform/transform_tensor.py
+++ b/hub/core/transform/transform_tensor.py
@@ -5,11 +5,10 @@ import numpy as np
 
 
 class TransformTensor:
-    def __init__(self, name, dataset, base_tensor=None, slice_list=None) -> None:
+    def __init__(self, name, dataset, items=None, slice_list=None) -> None:
         self.name = name
         self.dataset = dataset
-        self.items = [] if base_tensor is None else base_tensor.items
-        self.base_tensor = base_tensor or self
+        self.items = items or []
         self.slice_list = slice_list or []
         self.length = None
         self._ndim = None
@@ -27,7 +26,7 @@ class TransformTensor:
 
     def numpy_compressed(self):
         """Returns all the items stored in the slice of the tensor. Samples stored using hub.read are not converted to numpy arrays in this."""
-        value = self.items
+        value = self.items[:]
         for slice_ in self.slice_list:
             value = value[slice_]
         self.length = len(value) if isinstance(value, list) else 1
@@ -59,7 +58,7 @@ class TransformTensor:
         return TransformTensor(
             name=self.name,
             dataset=self.dataset,
-            base_tensor=self.base_tensor,
+            items=self.items,
             slice_list=new_slice_list,
         )
 

--- a/hub/util/transform.py
+++ b/hub/util/transform.py
@@ -182,7 +182,8 @@ def _transform_sample_and_update_chunk_engines(
         chunk_engine = all_chunk_engines[tensor]
         callback = chunk_engine._transform_callback
         chunk_engine.extend(value.numpy_compressed(), link_callback=callback)
-
+        value.clear()
+    import gc;gc.collect()
 
 def transform_data_slice_and_append(
     data_slice,

--- a/hub/util/transform.py
+++ b/hub/util/transform.py
@@ -183,7 +183,8 @@ def _transform_sample_and_update_chunk_engines(
         callback = chunk_engine._transform_callback
         chunk_engine.extend(value.numpy_compressed(), link_callback=callback)
         value.clear()
-    import gc;gc.collect()
+    # import gc; gc.collect()
+
 
 def transform_data_slice_and_append(
     data_slice,


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [ ]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [ ]  I have performed a self-review of my own code and resolved any problems
- [ ]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [ ]  New and existing unit tests pass locally with my changes


### Changes


Fix memory leak in transform

Test script:

```python
import hub
import numpy as np
import tracemalloc
import time
tracemalloc.start()

ds = hub.dataset('./data/mem_leak', overwrite=True)
ds.create_tensor('image', htype='image', sample_compression='jpeg')

@hub.compute
def process(i, ds_out):
    for _ in range(5100):
        img_np = np.random.randint(0, 255, size=(256, 256, 3), dtype=np.uint8)
        ds_out.append({'image': img_np})
    snapshot = tracemalloc.take_snapshot()
    top_stats = snapshot.statistics('lineno')
    for stat in top_stats[:2]:
        print(stat)

s = time.time()
process().eval(list(range(30)), ds, scheduler='threaded', num_workers=0)
e = time.time()

print(f"{e} - {s} seconds")
```

Benchmark:


| Branch                 | Memory (start) | Memory (end) | Object count (start) | Object count (end) | Run time |
|------------------------|----------------|--------------|----------------------|--------------------|----------|
| main                   | 957 MiB        | 10.3 GiB     | 15303                | 168303             | 86s      |
| fix/transform_mem_leak | 957 MiB        | 957 MiB      | 15303                | 15303              | 272s     |
| fr_fix_transform_leak  | 193 KiB        | 193 KiB      | 7                    | 7                  | 47s      |


<!-- Describe your changes! Describe the scope of this PR's responsibilities. -->