### PR TITLE
Fix get_incompatible_dtype bug

### DIFF
--- a/hub/api/tests/test_api.py
+++ b/hub/api/tests/test_api.py
@@ -2028,3 +2028,11 @@ def test_hub_token_without_permission(
     ds = hub.empty(
         "hub://testingacc/test_hub_token", token=hub_cloud_dev_token, overwrite=True
     )
+
+
+def test_incompat_dtype_msg(local_ds, capsys):
+    local_ds.create_tensor("abc", dtype="uint32")
+    with pytest.raises(TensorDtypeMismatchError):
+        local_ds.abc.append([0.0])
+    captured = capsys.readouterr()
+    assert "True" not in captured

--- a/hub/core/transform/transform.py
+++ b/hub/core/transform/transform.py
@@ -233,13 +233,14 @@ class Pipeline:
         for tensor in class_label_tensors:
             temp_tensor = f"_{tensor}_{uuid4().hex[:4]}"
             with target_ds:
-                target_ds.create_tensor(
+                temp_tensor_obj = target_ds.create_tensor(
                     temp_tensor,
-                    dtype=np.uint32,
+                    htype="class_label",
                     create_sample_info_tensor=False,
                     create_shape_tensor=False,
                     create_id_tensor=False,
                 )
+                temp_tensor_obj.meta._disable_temp_transform = True
                 label_temp_tensors[tensor] = temp_tensor
             target_ds.flush()
 

--- a/hub/util/casting.py
+++ b/hub/util/casting.py
@@ -136,7 +136,10 @@ def get_incompatible_dtype(
             else getattr(samples, "dtype", np.array(samples).dtype)
         )
     elif isinstance(samples, Sequence):
-        return all(map(lambda x: get_incompatible_dtype(x, dtype), samples))
+        for dt in map(lambda x: get_incompatible_dtype(x, dtype), samples):
+            if dt:
+                return dt
+        return None
     else:
         raise TypeError(
             f"Unexpected object {samples}. Expected np.ndarray, int, float, bool, str or Sequence."


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [ ]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [ ]  I have performed a self-review of my own code and resolved any problems
- [ ]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [ ]  New and existing unit tests pass locally with my changes


### Changes

<!-- Describe your changes! Describe the scope of this PR's responsibilities. -->