### PR TITLE
[DL-650] Better error handling when not passing a tensor name to ds.append

### DIFF
--- a/hub/api/tests/test_api.py
+++ b/hub/api/tests/test_api.py
@@ -30,6 +30,7 @@ from hub.util.exceptions import (
     InvalidTokenException,
     TokenPermissionError,
     UserNotLoggedInException,
+    SampleAppendingError,
 )
 from hub.util.path import convert_string_to_pathlib_if_needed
 from hub.util.pretty_print import summary_tensor, summary_dataset
@@ -1406,13 +1407,13 @@ def test_append_with_tensor(src_args, dest_args, size):
     ds2.y.append(ds1.x[0])
     np.testing.assert_array_equal(ds1.x.numpy(), ds2.y.numpy())
 
-    with pytest.raises(Exception):
+    with pytest.raises(SampleAppendingError):
         ds1.append(np.zeros((416, 416, 3)))
 
-    with pytest.raises(Exception):
+    with pytest.raises(SampleAppendingError):
         ds1.append(set())
 
-    with pytest.raises(Exception):
+    with pytest.raises(SampleAppendingError):
         ds1.append([1, 2, 3])
 
 

--- a/hub/api/tests/test_api.py
+++ b/hub/api/tests/test_api.py
@@ -1406,6 +1406,15 @@ def test_append_with_tensor(src_args, dest_args, size):
     ds2.y.append(ds1.x[0])
     np.testing.assert_array_equal(ds1.x.numpy(), ds2.y.numpy())
 
+    with pytest.raises(Exception):
+        ds1.append(np.zeros((416, 416, 3)))
+
+    with pytest.raises(Exception):
+        ds1.append(set())
+
+    with pytest.raises(Exception):
+        ds1.append([1, 2, 3])
+
 
 def test_extend_with_tensor():
     ds1 = hub.dataset("mem://ds1")

--- a/hub/core/dataset/dataset.py
+++ b/hub/core/dataset/dataset.py
@@ -80,6 +80,7 @@ from hub.util.exceptions import (
     DatasetViewSavingError,
     DatasetHandlerError,
     EmptyTensorError,
+    SampleAppendingError,
 )
 from hub.util.keys import (
     dataset_exists,
@@ -2073,9 +2074,7 @@ class Dataset:
         if isinstance(sample, Dataset):
             sample = sample.tensors
         if not isinstance(sample, dict):
-            raise Exception(
-                """Can not append sample because tensor name is not specified. If you want to append sample you need to either specify the tensor name and append sample as a dictionary, like: `ds.append({"tensor_name": sample})` or you need to call tensor method from the dataset like: `ds.tensor_name.append(sample)`"""
-            )
+            raise SampleAppendingError()
 
         skipped_tensors = [k for k in self.tensors if k not in sample]
         if skipped_tensors and not skip_ok and not append_empty:

--- a/hub/core/dataset/dataset.py
+++ b/hub/core/dataset/dataset.py
@@ -2060,6 +2060,7 @@ class Dataset:
             ValueError: If all tensors being updated are not of the same length.
             NotImplementedError: If an error occurs while writing tiles.
             Exception: Error while attempting to rollback appends.
+            SampleAppendingError: Error that occurs when someone tries to append a tensor value directly to the dataset without specifying tensor name.
 
         Examples:
 

--- a/hub/core/dataset/dataset.py
+++ b/hub/core/dataset/dataset.py
@@ -2072,9 +2072,7 @@ class Dataset:
         """
         if isinstance(sample, Dataset):
             sample = sample.tensors
-        if not isinstance(sample, Iterable) or (
-            isinstance(sample, Iterable) and not isinstance(sample, dict)
-        ):
+        if not isinstance(sample, dict):
             raise Exception(
                 """Can not append sample because tensor name is not specified. If you want to append sample you need to either specify the tensor name and append sample as a dictionary, like: `ds.append({"tensor_name": sample})` or you need to call tensor method from the dataset like: `ds.tensor_name.append(sample)`"""
             )

--- a/hub/experimental/dataloader.py
+++ b/hub/experimental/dataloader.py
@@ -219,7 +219,7 @@ class Hub3DataLoader:
                 tensors=tensors,
                 drop_last=drop_last,
                 upcast=upcast,
-                return_index=return_index
+                return_index=return_index,
             )
         )
 

--- a/hub/experimental/test_pytorch.py
+++ b/hub/experimental/test_pytorch.py
@@ -226,6 +226,7 @@ def test_string_tensors(local_ds):
     for idx, batch in enumerate(ptds):
         np.testing.assert_array_equal(batch["strings"], f"string{idx}")
 
+
 @requires_torch
 @requires_linux
 @pytest.mark.parametrize(
@@ -262,6 +263,7 @@ def test_pytorch_view(local_ds, index):
         np.testing.assert_array_equal(batch["img1"][0], arr_list_1[idx])
         np.testing.assert_array_equal(batch["img2"][0], arr_list_2[idx])
         np.testing.assert_array_equal(batch["label"][0], idx)
+
 
 @requires_torch
 @requires_linux

--- a/hub/remove_tensor.py
+++ b/hub/remove_tensor.py
@@ -1,5 +1,0 @@
-import hub
-
-
-ds = hub.load("hub://activeloop-test/SemanticKITTI-train")
-print(ds)

--- a/hub/remove_tensor.py
+++ b/hub/remove_tensor.py
@@ -1,0 +1,5 @@
+import hub
+
+
+ds = hub.load("hub://activeloop-test/SemanticKITTI-train")
+print(ds)

--- a/hub/util/exceptions.py
+++ b/hub/util/exceptions.py
@@ -768,3 +768,9 @@ class TokenPermissionError(Exception):
             "path and make sure that you have sufficient permissions to the path."
         )
         super().__init__(message)
+
+
+class SampleAppendingError(Exception):
+    def __init__(self):
+        message = """Can not append sample because tensor name is not specified. If you want to append sample you need to either specify the tensor name and append sample as a dictionary, like: `ds.append({"tensor_name": sample})` or you need to call tensor method from the dataset like: `ds.tensor_name.append(sample)`"""
+        super().__init__(message)

--- a/hub/util/exceptions.py
+++ b/hub/util/exceptions.py
@@ -772,5 +772,5 @@ class TokenPermissionError(Exception):
 
 class SampleAppendingError(Exception):
     def __init__(self):
-        message = """Can not append sample because tensor name is not specified. If you want to append sample you need to either specify the tensor name and append sample as a dictionary, like: `ds.append({"tensor_name": sample})` or you need to call tensor method from the dataset like: `ds.tensor_name.append(sample)`"""
+        message = """Cannot append sample because tensor(s) are not specified. To append samples, you need to either specify the tensors and append the samples as a dictionary, like: `ds.append({"image_tensor": sample, "label_tensor": sample})` or you need to call `append` method of the required tensor, like: `ds.image_tensor.append(sample)`"""
         super().__init__(message)

--- a/hub/util/exceptions.py
+++ b/hub/util/exceptions.py
@@ -772,5 +772,5 @@ class TokenPermissionError(Exception):
 
 class SampleAppendingError(Exception):
     def __init__(self):
-        message = """Cannot append sample because tensor(s) are not specified. To append samples, you need to either specify the tensors and append the samples as a dictionary, like: `ds.append({"image_tensor": sample, "label_tensor": sample})` or you need to call `append` method of the required tensor, like: `ds.image_tensor.append(sample)`"""
+        message = """Cannot append sample because tensor(s) are not specified. Expected input to ds.append is a dictionary. To append samples, you need to either specify the tensors and append the samples as a dictionary, like: `ds.append({"image_tensor": sample, "label_tensor": sample})` or you need to call `append` method of the required tensor, like: `ds.image_tensor.append(sample)`"""
         super().__init__(message)


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [ ]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [ ]  I have performed a self-review of my own code and resolved any problems
- [ ]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [ ]  New and existing unit tests pass locally with my changes


### Changes

Added Error message that is thrown when user tries to append a sample and does not provide the the name of the tensor.