### PR TITLE
[Bug fix] Ensure None/"ENV" isn't added to used_creds_keys for linked data

### DIFF
--- a/hub/api/tests/test_link.py
+++ b/hub/api/tests/test_link.py
@@ -188,6 +188,23 @@ def test_add_populate_creds(local_ds_generator):
     assert ds.link_creds.creds_dict == {}
 
 
+def test_none_used_key(local_ds_generator, cat_path):
+    local_ds = local_ds_generator()
+    with local_ds as ds:
+        ds.create_tensor("xyz", htype="link[image]")
+        ds.add_creds_key("my_s3_key")
+        ds.populate_creds("my_s3_key", {})
+        ds.xyz.append(hub.link(cat_path))
+        assert ds.link_creds.used_creds_keys == set()
+        ds.xyz.append(hub.link(cat_path, "ENV"))
+        assert ds.link_creds.used_creds_keys == set()
+        ds.xyz.append(hub.link(cat_path, "my_s3_key"))
+        assert ds.link_creds.used_creds_keys == {"my_s3_key"}
+
+    ds = local_ds_generator()
+    assert ds.link_creds.used_creds_keys == {"my_s3_key"}
+
+
 @pytest.mark.parametrize("create_shape_tensor", [True, False])
 @pytest.mark.parametrize("verify", [True, False])
 def test_basic(local_ds_generator, cat_path, flower_path, create_shape_tensor, verify):

--- a/hub/core/link_creds.py
+++ b/hub/core/link_creds.py
@@ -132,11 +132,11 @@ class LinkCreds(HubMemoryObject):
         expires_in_to_expires_at(creds)
         self.creds_dict[creds_key] = creds
 
-    def add_to_used_creds(self, creds_key: str):
-        if creds_key not in self.used_creds_keys:
-            self.used_creds_keys.add(creds_key)
-            return True
-        return False
+    def add_to_used_creds(self, creds_key: Optional[str]):
+        if creds_key in {"ENV", None} or creds_key in self.used_creds_keys:
+            return False
+        self.used_creds_keys.add(creds_key)
+        return True
 
     def tobytes(self) -> bytes:
         d = {


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [ ]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [ ]  I have performed a self-review of my own code and resolved any problems
- [ ]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [ ]  New and existing unit tests pass locally with my changes


### Changes
- None/"ENV" is no longer added to used_creds_keys for linked data