### PR TITLE
[AL-1912] Don't allow generic htypes with link

### DIFF
--- a/hub/api/tests/test_insertion_out_of_order.py
+++ b/hub/api/tests/test_insertion_out_of_order.py
@@ -153,7 +153,7 @@ def test_updation_bug(memory_ds):
 @pytest.mark.parametrize("insert_first", [False, True])
 def test_insertion_link(memory_ds, insert_first, cat_path, flower_path):
     with memory_ds as ds:
-        ds.create_tensor("abc", htype="link")
+        ds.create_tensor("abc", htype="link[image]")
         first = hub.link(cat_path)
         tenth = hub.link(flower_path)
         empty_sample = np.ones((0,))

--- a/hub/api/tests/test_link.py
+++ b/hub/api/tests/test_link.py
@@ -21,25 +21,19 @@ from hub.util.htype import parse_complex_htype  # type: ignore
 
 
 def test_complex_htype_parsing():
-    is_sequence, is_link, htype = parse_complex_htype("link")
-    assert not is_sequence
-    assert is_link
-    assert htype == "generic"
+    with pytest.raises(ValueError):
+        is_sequence, is_link, htype = parse_complex_htype("link")
 
     is_sequence, is_link, htype = parse_complex_htype("sequence")
     assert is_sequence
     assert not is_link
     assert htype == "generic"
 
-    is_sequence, is_link, htype = parse_complex_htype("sequence[link]")
-    assert is_sequence
-    assert is_link
-    assert htype == "generic"
+    with pytest.raises(ValueError):
+        is_sequence, is_link, htype = parse_complex_htype("sequence[link]")
 
-    is_sequence, is_link, htype = parse_complex_htype("link[sequence]")
-    assert is_sequence
-    assert is_link
-    assert htype == "generic"
+    with pytest.raises(ValueError):
+        is_sequence, is_link, htype = parse_complex_htype("link[sequence]")
 
     is_sequence, is_link, htype = parse_complex_htype("sequence[image]")
     assert is_sequence

--- a/hub/api/tests/test_pop.py
+++ b/hub/api/tests/test_pop.py
@@ -60,7 +60,7 @@ def test_multiple(local_ds_generator):
 
 def test_link_pop(local_ds_generator, cat_path, flower_path):
     with local_ds_generator() as ds:
-        ds.create_tensor("xyz", htype="link")
+        ds.create_tensor("xyz", htype="link[image]")
         for i in range(10):
             url = cat_path if i % 2 == 0 else flower_path
             ds.xyz.append(hub.link(url))

--- a/hub/api/tests/test_rechunk.py
+++ b/hub/api/tests/test_rechunk.py
@@ -197,7 +197,7 @@ def test_rechunk_list(local_ds_generator):
 def test_rechunk_link(local_ds_generator, cat_path, flower_path, color_image_paths):
     dog_path = color_image_paths["jpeg"]
     with local_ds_generator() as ds:
-        ds.create_tensor("abc", "link")
+        ds.create_tensor("abc", "link[image]")
         add_sample_in().eval(
             [hub.link(dog_path), hub.link(flower_path), hub.link(cat_path)],
             ds,

--- a/hub/core/chunk/base_chunk.py
+++ b/hub/core/chunk/base_chunk.py
@@ -286,6 +286,13 @@ class BaseChunk(HubMemoryObject):
         )
         if tiling_threshold < 0:
             break_into_tiles = False
+
+        if isinstance(incoming_sample, LinkedSample):
+            if self.tensor_meta.is_link:
+                incoming_sample = incoming_sample.path
+            else:
+                raise ValueError("Can't append with hub.link() to tensor whose htype is not 'link'")
+        
         if self.is_text_like:
             if isinstance(incoming_sample, LinkedSample):
                 incoming_sample = incoming_sample.path

--- a/hub/core/chunk/base_chunk.py
+++ b/hub/core/chunk/base_chunk.py
@@ -291,8 +291,10 @@ class BaseChunk(HubMemoryObject):
             if self.tensor_meta.is_link:
                 incoming_sample = incoming_sample.path
             else:
-                raise ValueError("Can't append with hub.link() to tensor whose htype is not 'link'")
-        
+                raise ValueError(
+                    "hub.link() samples can only be appended to linked tensors. To create linked tensors, include link in htype during create_tensor, for example 'link[image]'."
+                )
+
         if self.is_text_like:
             if isinstance(incoming_sample, LinkedSample):
                 incoming_sample = incoming_sample.path

--- a/hub/core/link_creds.py
+++ b/hub/core/link_creds.py
@@ -133,7 +133,7 @@ class LinkCreds(HubMemoryObject):
         self.creds_dict[creds_key] = creds
 
     def add_to_used_creds(self, creds_key: Optional[str]):
-        if creds_key in {"ENV", None} or creds_key in self.used_creds_keys:
+        if creds_key is None or creds_key in self.used_creds_keys:
             return False
         self.used_creds_keys.add(creds_key)
         return True

--- a/hub/core/linked_sample.py
+++ b/hub/core/linked_sample.py
@@ -1,7 +1,8 @@
-from typing import Dict, Optional
+from typing import Optional
+from hub.util.link import convert_creds_key
 
 
 class LinkedSample:
     def __init__(self, path: str, creds_key: Optional[str] = None):
         self.path = path
-        self.creds_key = creds_key
+        self.creds_key = convert_creds_key(creds_key, path)

--- a/hub/core/linked_sample.py
+++ b/hub/core/linked_sample.py
@@ -1,5 +1,13 @@
 from typing import Optional
-from hub.util.link import convert_creds_key
+from hub.constants import ALL_CLOUD_PREFIXES
+
+
+def convert_creds_key(creds_key: Optional[str], path: str):
+    if creds_key is None and path.startswith(ALL_CLOUD_PREFIXES):
+        creds_key = "ENV"
+    elif creds_key == "ENV" and not path.startswith(ALL_CLOUD_PREFIXES):
+        creds_key = None
+    return creds_key
 
 
 class LinkedSample:

--- a/hub/core/transform/test_transform.py
+++ b/hub/core/transform/test_transform.py
@@ -972,7 +972,7 @@ def test_transform_bug_text(local_ds):
 
 def test_transform_bug_link(local_ds, cat_path):
     with local_ds as ds:
-        ds.create_tensor("abc", htype="link")
+        ds.create_tensor("abc", htype="link[image]")
         ls = [cat_path] * 10
         add_link().eval(ls, ds, num_workers=2)
         assert len(ds) == 10

--- a/hub/util/htype.py
+++ b/hub/util/htype.py
@@ -23,8 +23,12 @@ def parse_complex_htype(htype: Optional[str]) -> Tuple[bool, bool, str]:
 
     if is_link and htype == HTYPE.DEFAULT:
         if is_sequence:
-            raise ValueError("Can't create a linked tensor with a generic htype, you need to specify htype, for example sequence[link[image]] or link[sequence[image]]")
-        raise ValueError("Can't create a linked tensor with a generic htype, you need to specify htype, for example link[image]")
+            raise ValueError(
+                "Can't create a linked tensor with a generic htype, you need to specify htype, for example sequence[link[image]] or link[sequence[image]]"
+            )
+        raise ValueError(
+            "Can't create a linked tensor with a generic htype, you need to specify htype, for example link[image]"
+        )
     return is_sequence, is_link, htype
 
 

--- a/hub/util/htype.py
+++ b/hub/util/htype.py
@@ -21,6 +21,10 @@ def parse_complex_htype(htype: Optional[str]) -> Tuple[bool, bool, str]:
     if "[" in htype or "]" in htype:
         raise TensorMetaInvalidHtype(htype, list(HTYPE_CONFIGURATIONS))
 
+    if is_link and htype == HTYPE.DEFAULT:
+        if is_sequence:
+            raise ValueError("Can't create a linked tensor with a generic htype, you need to specify htype, for example sequence[link[image]] or link[sequence[image]]")
+        raise ValueError("Can't create a linked tensor with a generic htype, you need to specify htype, for example link[image]")
     return is_sequence, is_link, htype
 
 

--- a/hub/util/link.py
+++ b/hub/util/link.py
@@ -1,4 +1,3 @@
-from hub.constants import ALL_CLOUD_PREFIXES
 from hub.core.link_creds import LinkCreds
 from hub.core.lock import Lock
 from hub.core.storage.lru_cache import LRUCache
@@ -83,11 +82,3 @@ def get_path_creds_key(sample):
     if sample is None:
         return None, None
     return sample.path, sample.creds_key
-
-
-def convert_creds_key(creds_key: Optional[str], path: str):
-    if creds_key is None and path.startswith(ALL_CLOUD_PREFIXES):
-        creds_key = "ENV"
-    elif creds_key == "ENV" and not path.startswith(ALL_CLOUD_PREFIXES):
-        creds_key = None
-    return creds_key

--- a/hub/util/link.py
+++ b/hub/util/link.py
@@ -1,6 +1,5 @@
 from hub.constants import ALL_CLOUD_PREFIXES
 from hub.core.link_creds import LinkCreds
-from hub.core.linked_sample import LinkedSample
 from hub.core.lock import Lock
 from hub.core.storage.lru_cache import LRUCache
 from hub.util.keys import (
@@ -80,7 +79,7 @@ def save_link_creds(
     lock.release()
 
 
-def get_path_creds_key(sample: Optional[LinkedSample]):
+def get_path_creds_key(sample):
     if sample is None:
         return None, None
     return sample.path, sample.creds_key

--- a/hub/util/link.py
+++ b/hub/util/link.py
@@ -1,3 +1,4 @@
+from hub.constants import ALL_CLOUD_PREFIXES
 from hub.core.link_creds import LinkCreds
 from hub.core.linked_sample import LinkedSample
 from hub.core.lock import Lock
@@ -83,3 +84,11 @@ def get_path_creds_key(sample: Optional[LinkedSample]):
     if sample is None:
         return None, None
     return sample.path, sample.creds_key
+
+
+def convert_creds_key(creds_key: Optional[str], path: str):
+    if creds_key is None and path.startswith(ALL_CLOUD_PREFIXES):
+        creds_key = "ENV"
+    elif creds_key == "ENV" and not path.startswith(ALL_CLOUD_PREFIXES):
+        creds_key = None
+    return creds_key


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [ ]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [ ]  I have performed a self-review of my own code and resolved any problems
- [ ]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [ ]  New and existing unit tests pass locally with my changes


### Changes
- Raises ValueError when generic htypes are used with links. So now, htype= "link' or "sequence[link]" or "link[sequence]" are no longer allowed.
- Raises a more informative error if user tries to append hub.link sample to a tensor that isn't a link.