### PR TITLE
[Bugfix] 1828 raising UserNotLoggedInException when invalid path is provided

### DIFF
--- a/hub/api/tests/test_api.py
+++ b/hub/api/tests/test_api.py
@@ -2032,7 +2032,10 @@ def test_uneven_iteration(memory_ds):
 
 
 def TokenPermissionError_check(
-    username, password, runner, hub_cloud_dev_token,
+    username,
+    password,
+    runner,
+    hub_cloud_dev_token,
 ):
     result = runner.invoke(login, f"-u {username} -p {password}")
     with pytest.raises(TokenPermissionError):
@@ -2052,20 +2055,13 @@ def InvalidTokenException_check():
         ds = hub.empty("hub://adilkhan/demo", token="invalid_token")
 
 
-def UserNotLoggedInException_check(
-    hub_cloud_dev_credentials
-):
-    username, password = hub_cloud_dev_credentials
-    runner = CliRunner()
+def UserNotLoggedInException_check(runner):
+    runner.invoke(logout)
     with pytest.raises(UserNotLoggedInException):
-       runner.invoke(logout)
+        ds = hub.load("hub://activeloop-test/sohas-weapons-train", read_only=True)
 
 
-def DatasetHandlerError_check(
-    hub_cloud_dev_credentials
-):
-    username, password = hub_cloud_dev_credentials
-    runner = CliRunner()
+def DatasetHandlerError_check(runner, username, password):
     result = runner.invoke(login, f"-u {username} -p {password}")
     with pytest.raises(DatasetHandlerError):
         ds = hub.load(f"hub://{username}/wrong-path")
@@ -2078,15 +2074,14 @@ def test_hub_related_permission_exceptions(
     runner = CliRunner()
 
     TokenPermissionError_check(
-        username, password, runner, hub_cloud_dev_token,
+        username,
+        password,
+        runner,
+        hub_cloud_dev_token,
     )
     InvalidTokenException_check()
-    UserNotLoggedInException_check(
-        hub_cloud_dev_credentials
-    )
-    DatasetHandlerError_check(
-        hub_cloud_dev_credentials
-    )
+    UserNotLoggedInException_check(runner)
+    DatasetHandlerError_check(runner, username, password)
 
 
 def test_incompat_dtype_msg(local_ds, capsys):

--- a/hub/api/tests/test_api.py
+++ b/hub/api/tests/test_api.py
@@ -2031,7 +2031,7 @@ def test_uneven_iteration(memory_ds):
             np.testing.assert_equal(y, target_y)
 
 
-def TokenPermissionError_check(
+def token_permission_error_check(
     username,
     password,
     runner,
@@ -2044,18 +2044,18 @@ def TokenPermissionError_check(
         ds = hub.load("hub://activeloop/fake-path")
 
 
-def InvalidTokenException_check():
+def invalid_token_exception_check():
     with pytest.raises(InvalidTokenException):
         ds = hub.empty("hub://adilkhan/demo", token="invalid_token")
 
 
-def UserNotLoggedInException_check(runner):
+def user_not_logged_in_exception_check(runner):
     runner.invoke(logout)
     with pytest.raises(UserNotLoggedInException):
         ds = hub.load("hub://activeloop-test/sohas-weapons-train", read_only=True)
 
 
-def DatasetHandlerError_check(runner, username, password):
+def dataset_handler_error_check(runner, username, password):
     result = runner.invoke(login, f"-u {username} -p {password}")
     with pytest.raises(DatasetHandlerError):
         ds = hub.load(f"hub://{username}/wrong-path")
@@ -2067,14 +2067,14 @@ def test_hub_related_permission_exceptions(
     username, password = hub_cloud_dev_credentials
     runner = CliRunner()
 
-    TokenPermissionError_check(
+    token_permission_error_check(
         username,
         password,
         runner,
     )
-    InvalidTokenException_check()
-    UserNotLoggedInException_check(runner)
-    DatasetHandlerError_check(runner, username, password)
+    invalid_token_exception_check()
+    user_not_logged_in_exception_check(runner)
+    dataset_handler_error_check(runner, username, password)
 
 
 def test_incompat_dtype_msg(local_ds, capsys):

--- a/hub/api/tests/test_api.py
+++ b/hub/api/tests/test_api.py
@@ -2035,16 +2035,10 @@ def TokenPermissionError_check(
     username,
     password,
     runner,
-    hub_cloud_dev_token,
 ):
     result = runner.invoke(login, f"-u {username} -p {password}")
     with pytest.raises(TokenPermissionError):
         hub.empty("hub://activeloop-test/sohas-weapons-train")
-
-    runner.invoke(logout)
-    ds = hub.empty(
-        "hub://testingacc/test_hub_token", token=hub_cloud_dev_token, overwrite=True
-    )
 
     with pytest.raises(TokenPermissionError):
         ds = hub.load("hub://activeloop/fake-path")
@@ -2077,7 +2071,6 @@ def test_hub_related_permission_exceptions(
         username,
         password,
         runner,
-        hub_cloud_dev_token,
     )
     InvalidTokenException_check()
     UserNotLoggedInException_check(runner)

--- a/hub/api/tests/test_api.py
+++ b/hub/api/tests/test_api.py
@@ -2062,6 +2062,9 @@ def test_hub_token_without_permission(
         "hub://testingacc/test_hub_token", token=hub_cloud_dev_token, overwrite=True
     )
 
+    with pytest.raises(TokenPermissionError):
+        ds = hub.load("hub://activeloop/fake-path")
+
 
 def test_incompat_dtype_msg(local_ds, capsys):
     local_ds.create_tensor("abc", dtype="uint32")

--- a/hub/client/client.py
+++ b/hub/client/client.py
@@ -41,13 +41,8 @@ import jwt  # should add it to requirements.txt
 retry_status_codes = {502}
 
 
-def response_data_to_error_type_converter():
-
-
-
 ERROR_TYPE_TO_RESPONSE_DATA_DESCRIPTION = {
     TokenPermissionError: "You don't have permission to access this dataset",
-
 }
 
 
@@ -227,6 +222,7 @@ class HubBackendClient:
             ).json()
         except Exception as e:
             if isinstance(e, AuthorizationException):
+                authorization_exception_prompt = "You don't have permission to access"
                 response_data = e.response.json()
                 code = response_data.get("code")
                 if code == 1:
@@ -243,7 +239,7 @@ class HubBackendClient:
                     except Exception:
                         raise InvalidTokenException
 
-                    if decoded_token["id"] == "public":
+                    if authorization_exception_prompt in response_data["description"]:
                         raise UserNotLoggedInException()
                     raise TokenPermissionError()
             raise

--- a/hub/client/client.py
+++ b/hub/client/client.py
@@ -225,6 +225,8 @@ class HubBackendClient:
                     raise AgreementNotAcceptedError(agreements) from e
                 elif code == 2:
                     raise NotLoggedInAgreementError from e
+                else:
+                    raise TokenPermissionError()
             try:
                 decoded_token = jwt.decode(
                     self.token, options={"verify_signature": False}
@@ -233,8 +235,6 @@ class HubBackendClient:
                 raise InvalidTokenException
             if decoded_token["id"] == "public":
                 raise UserNotLoggedInException()
-            if isinstance(e, AuthorizationException):
-                raise TokenPermissionError()
             raise
 
         full_url = response.get("path")

--- a/hub/client/client.py
+++ b/hub/client/client.py
@@ -41,11 +41,6 @@ import jwt  # should add it to requirements.txt
 retry_status_codes = {502}
 
 
-ERROR_TYPE_TO_RESPONSE_DATA_DESCRIPTION = {
-    TokenPermissionError: "You don't have permission to access this dataset",
-}
-
-
 class HubBackendClient:
     """Communicates with Activeloop Backend"""
 
@@ -222,7 +217,7 @@ class HubBackendClient:
             ).json()
         except Exception as e:
             if isinstance(e, AuthorizationException):
-                authorization_exception_prompt = "You don't have permission to access"
+                authorization_exception_prompt = "You don't have permission to "
                 response_data = e.response.json()
                 code = response_data.get("code")
                 if code == 1:
@@ -239,7 +234,10 @@ class HubBackendClient:
                     except Exception:
                         raise InvalidTokenException
 
-                    if authorization_exception_prompt in response_data["description"]:
+                    if (
+                        authorization_exception_prompt in response_data["description"]
+                        and decoded_token["id"] == "public"
+                    ):
                         raise UserNotLoggedInException()
                     raise TokenPermissionError()
             raise


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [ ]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [ ]  I have performed a self-review of my own code and resolved any problems
- [ ]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [ ]  New and existing unit tests pass locally with my changes


### Changes

Fixed bug related to raising UserNotLoggedInException when public user tries to access the public path that does not exists