### PR TITLE
[DL-684] Fix ds.reset bug with local datasets

### DIFF
--- a/hub/core/storage/local.py
+++ b/hub/core/storage/local.py
@@ -31,6 +31,7 @@ class LocalProvider(StorageProvider):
             raise FileAtPathException(root)
         self.root = root
         self.files: Optional[Set[str]] = None
+        self._all_keys()
 
     def subdir(self, path: str):
         return self.__class__(os.path.join(self.root, path))

--- a/hub/core/version_control/test_version_control.py
+++ b/hub/core/version_control/test_version_control.py
@@ -1891,3 +1891,17 @@ def test_reset_create_delete_tensors(local_ds):
         assert set(ds.tensors.keys()) == {"one", "three"}
         ds.reset()
         assert set(ds.tensors.keys()) == {"one", "two"}
+
+
+def test_local_reset_bug(local_ds_generator):
+    ds = local_ds_generator()
+    ds.create_tensor("abc")
+    ds.abc.append([1, 2, 3])
+    assert len(ds.abc) == 1
+    a = ds.commit()
+
+    ds = local_ds_generator()
+    ds.abc.append([3, 4, 5])
+    assert len(ds.abc) == 2
+    ds.reset()
+    assert len(ds.abc) == 1

--- a/hub/core/version_control/test_version_control.py
+++ b/hub/core/version_control/test_version_control.py
@@ -16,10 +16,6 @@ from hub.util.exceptions import (
     TensorModifiedError,
     EmptyCommitError,
 )
-from hub.tests.dataset_fixtures import (
-    ds_generator,
-    enabled_persistent_dataset_generators,
-)
 
 NO_COMMIT_PASSED_DIFF = ""
 ONE_COMMIT_PASSED_DIFF = "The 2 diffs are calculated relative to the most recent common ancestor (%s) of the current state and the commit passed."

--- a/hub/core/version_control/test_version_control.py
+++ b/hub/core/version_control/test_version_control.py
@@ -16,6 +16,10 @@ from hub.util.exceptions import (
     TensorModifiedError,
     EmptyCommitError,
 )
+from hub.tests.dataset_fixtures import (
+    ds_generator,
+    enabled_persistent_dataset_generators,
+)
 
 NO_COMMIT_PASSED_DIFF = ""
 ONE_COMMIT_PASSED_DIFF = "The 2 diffs are calculated relative to the most recent common ancestor (%s) of the current state and the commit passed."
@@ -1893,14 +1897,24 @@ def test_reset_create_delete_tensors(local_ds):
         assert set(ds.tensors.keys()) == {"one", "two"}
 
 
-def test_local_reset_bug(local_ds_generator):
-    ds = local_ds_generator()
+@pytest.mark.parametrize(
+    "ds_generator",
+    [
+        "local_ds_generator",
+        "s3_ds_generator",
+        "gcs_ds_generator",
+        "hub_cloud_ds_generator",
+    ],
+    indirect=True,
+)
+def test_reset_bug(ds_generator):
+    ds = ds_generator()
     ds.create_tensor("abc")
     ds.abc.append([1, 2, 3])
     assert len(ds.abc) == 1
     a = ds.commit()
 
-    ds = local_ds_generator()
+    ds = ds_generator()
     ds.abc.append([3, 4, 5])
     assert len(ds.abc) == 2
     ds.reset()


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [ ]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [ ]  I have performed a self-review of my own code and resolved any problems
- [ ]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [ ]  New and existing unit tests pass locally with my changes


### Changes

<!-- Describe your changes! Describe the scope of this PR's responsibilities. -->