### PR TITLE
Ensure that new format for chunk id isn't used for encoders with version <= 2.7.6

### DIFF
--- a/hub/core/serialize.py
+++ b/hub/core/serialize.py
@@ -273,11 +273,12 @@ def serialize_chunkids(version: str, arr: np.ndarray) -> memoryview:
     flatbuff[1 : 1 + len_version] = version.encode("ascii")
     offset = 1 + len_version
 
-    # write number of bytes per entry
-    dtype = arr.dtype
-    num_bytes = int(dtype.itemsize)
-    flatbuff[offset] = num_bytes
-    offset += 1
+    # write encoder dtype
+    if version_compare(version, "2.7.6") >= 0:
+        dtype = arr.dtype
+        num_bytes = int(dtype.itemsize)
+        flatbuff[offset] = num_bytes
+        offset += 1
 
     # Write ids
     flatbuff[offset : offset + arr.nbytes] = arr.tobytes()

--- a/hub/core/serialize.py
+++ b/hub/core/serialize.py
@@ -305,7 +305,7 @@ def deserialize_chunkids(
     len_version = byts[0]
     version = str(byts[1 : 1 + len_version], "ascii")
     offset = 1 + len_version
-    if version_compare(version, "2.7.6") < 0:  # change this to 2.8.0 closer to release
+    if version_compare(version, "2.7.6") < 0:
         # Read chunk ids
         ids = np.frombuffer(byts[offset:], dtype=np.uint32).reshape(-1, 2).copy()
         return version, ids, np.uint32


### PR DESCRIPTION
## 🚀 🚀 Pull Request

### Checklist:

- [ ]  [My code follows the style guidelines of this project](https://www.notion.so/activeloop/Engineering-Guidelines-d6e502306d0e4133a8ca507516d1baab) and the [Contributing document](https://github.com/activeloopai/Hub/blob/release/2.0/CONTRIBUTING.md)
- [ ]  I have commented my code, particularly in hard-to-understand areas
- [ ]  I have kept the `coverage-rate` up
- [ ]  I have performed a self-review of my own code and resolved any problems
- [ ]  I have checked to ensure there aren't any other open [Pull Requests](https://github.com/activeloopai/Hub/pulls) for the same change
- [ ]  I have described and made corresponding changes to the relevant documentation
- [ ]  New and existing unit tests pass locally with my changes


### Changes

<!-- Describe your changes! Describe the scope of this PR's responsibilities. -->